### PR TITLE
Added option of trackball following the robot

### DIFF
--- a/Library/include/graphics/OpenGLDataStructs.h
+++ b/Library/include/graphics/OpenGLDataStructs.h
@@ -368,6 +368,7 @@ namespace sf
         bool showFluidDynamics;
         bool showForces;
         bool showBulletDebugInfo;
+        bool followRobotMode;
         
         //! A constructor.
         HelperSettings()
@@ -379,6 +380,7 @@ namespace sf
             showFluidDynamics = false;
             showForces = false;
             showBulletDebugInfo = false;
+            followRobotMode = false;
         }
     };
     

--- a/Library/include/graphics/OpenGLTrackball.h
+++ b/Library/include/graphics/OpenGLTrackball.h
@@ -62,6 +62,12 @@ namespace sf
          \param step a position step [m]
          */
         void MoveCenter(glm::vec3 step);
+
+        //! A method to set the center of the trackball orbit.
+        /*!
+         \param set a position [m]
+         */
+        void SetCenter(glm::vec3 new_center);
         
         //! A method to glue the trackball to a rigid body.
         /*!

--- a/Library/src/core/GraphicalSimulationApp.cpp
+++ b/Library/src/core/GraphicalSimulationApp.cpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <thread>
 #include "core/SimulationManager.h"
+#include "core/Robot.h"
 #include "graphics/GLSLShader.h"
 #include "graphics/OpenGLPipeline.h"
 #include "graphics/OpenGLConsole.h"
@@ -432,8 +433,15 @@ void GraphicalSimulationApp::Loop()
     
     while(!hasFinished())
     {
+
+        if (getHelperSettings().followRobotMode) {
+            OpenGLTrackball* trackball = getSimulationManager()->getTrackball();
+            Vector3 trans = getSimulationManager()->getRobot(0)->getTransform().getOrigin();
+            trackball->SetCenter(glm::vec3(trans.getX(), trans.getY(), trans.getZ()));
+        }
+
         SDL_FlushEvents(SDL_FINGERDOWN, SDL_MULTIGESTURE);
-            
+
         while(SDL_PollEvent(&event))
         {
             switch(event.type)
@@ -679,6 +687,10 @@ void GraphicalSimulationApp::DoHUD()
         hs.showFluidDynamics = gui->DoCheckBox(id, 15.f, offset, 110.f, hs.showFluidDynamics, "Hydrodynamics");
         offset += 22.f;
     }
+
+    id.item = 8;
+    hs.followRobotMode = gui->DoCheckBox(id, 15.f, offset, 110.f, hs.followRobotMode, "Follow robot");
+    offset += 22.f;
     
     offset += 14.f;
     

--- a/Library/src/graphics/OpenGLTrackball.cpp
+++ b/Library/src/graphics/OpenGLTrackball.cpp
@@ -164,6 +164,12 @@ void OpenGLTrackball::MoveCenter(glm::vec3 step)
     UpdateTrackballTransform();
 }
 
+void OpenGLTrackball::SetCenter(glm::vec3 new_center)
+{
+    center = new_center;
+    UpdateTrackballTransform();
+}
+
 void OpenGLTrackball::GlueToEntity(SolidEntity* solid)
 {
     holdingEntity = solid;


### PR DESCRIPTION
@patrykcieslak  This PR adds the option to let the trackball follow robot number 0. I added this as a toggle in the graphical interface as well. This is very convenient if you have a robot that is moving across a larger area. Works smoothly from my tests.