### PR TITLE
Allow configuring shader dir at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,22 +53,22 @@ else()
     # Install library in the system
     install(
         TARGETS Stonefish 
-        LIBRARY DESTINATION /usr/local/lib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
     )
     
     # Install Stonefish headers
-    install(DIRECTORY Library/include/ DESTINATION /usr/local/include/Stonefish)
+    install(DIRECTORY Library/include/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Stonefish)
     
     # Install 3rdparty headers
     file(GLOB_RECURSE INCLUDES_3RD "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/*.h")
     foreach(f ${INCLUDES_3RD})
         file(RELATIVE_PATH frel "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty" ${f})
         get_filename_component(dir ${frel} DIRECTORY)
-        install(FILES ${f} DESTINATION /usr/local/include/Stonefish/${dir})
+        install(FILES ${f} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Stonefish/${dir})
     endforeach()
     
     #Install other files
-    install(DIRECTORY Library/shaders/ DESTINATION /usr/local/share/Stonefish/shaders)
-    install(FILES ${PROJECT_BINARY_DIR}/version.h DESTINATION /usr/local/include/Stonefish)
-    install(FILES ${PROJECT_BINARY_DIR}/stonefish.pc DESTINATION /usr/local/lib/pkgconfig)
+    install(DIRECTORY Library/shaders/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/Stonefish/shaders)
+    install(FILES ${PROJECT_BINARY_DIR}/version.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Stonefish)
+    install(FILES ${PROJECT_BINARY_DIR}/stonefish.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 endif()

--- a/Library/include/core/GraphicalSimulationApp.h
+++ b/Library/include/core/GraphicalSimulationApp.h
@@ -50,7 +50,7 @@ namespace sf
          \param h a structure containing the helper objects display settings
          \param sim a pointer to the simulation manager
          */
-        GraphicalSimulationApp(std::string name, std::string dataDirPath, RenderSettings s, HelperSettings h, SimulationManager* sim);
+        GraphicalSimulationApp(std::string name, std::string dataDirPath, RenderSettings s, HelperSettings h, SimulationManager* sim, const std::string& shaderPath="/usr/local/share/Stonefish/shaders/");
         
         //! A destructor.
         virtual ~GraphicalSimulationApp();

--- a/Library/src/core/GraphicalSimulationApp.cpp
+++ b/Library/src/core/GraphicalSimulationApp.cpp
@@ -45,13 +45,13 @@
 namespace sf
 {
 
-GraphicalSimulationApp::GraphicalSimulationApp(std::string name, std::string dataDirPath, RenderSettings r, HelperSettings h, SimulationManager* sim)
+GraphicalSimulationApp::GraphicalSimulationApp(std::string name, std::string dataDirPath, RenderSettings r, HelperSettings h, SimulationManager* sim, const std::string& shaderPath)
 : SimulationApp(name, dataDirPath, sim)
 {
 #ifdef SHADER_DIR_PATH
-    shaderPath = SHADER_DIR_PATH;
+    this->shaderPath = SHADER_DIR_PATH;
 #else
-    shaderPath = "/usr/local/share/Stonefish/shaders/";
+    this->shaderPath = shaderPath;
 #endif
     glLoadingContext = NULL;
     glMainContext = NULL;


### PR DESCRIPTION
This change adds an optional argument for the shader dir path. If not used, the API is identical to before, as well as the behavior. This allows using a different install path, as enabled by https://github.com/patrykcieslak/stonefish/pull/13 .