### PR TITLE
Fix compilation errors

### DIFF
--- a/Library/include/StonefishCommon.h
+++ b/Library/include/StonefishCommon.h
@@ -29,6 +29,7 @@
 //STL
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 //Bullet Physics
 #include "btBulletDynamicsCommon.h"

--- a/Tests/FallingTest/FallingTestManager.cpp
+++ b/Tests/FallingTest/FallingTestManager.cpp
@@ -36,7 +36,7 @@
 #include <entities/solids/Sphere.h>
 #include <entities/solids/Torus.h>
 #include <entities/solids/Cylinder.h>
-#include <entities/CableEntity.h>
+// #include <entities/CableEntity.h>
 #include <graphics/OpenGLContent.h>
 #include <sensors/scalar/IMU.h>
 #include <sensors/scalar/RotaryEncoder.h>


### PR DESCRIPTION
Two simple issues are fixed with this commit:
1. `std::out_of_range` exception is inside the `#include <stdexcept>`. If its not included, gcc11 throws an error. The library included in StonefishCommon.h file.
2. cable entity was creating a problem when tests were building. I commented it out.