### PR TITLE
Changes for Microsoft Visual C++ compiler (2022) compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,12 @@ option(EMBED_RESOURCES "Embed internal resources in the library executable" OFF)
 # Compile flags
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -DDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+if(MSVC)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS YES CACHE BOOL "Export all symbols")
+else()
+    set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -DDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+endif()
 set(OpenGL_GL_PREFERENCE "GLVND")
 
 # Find required libraries

--- a/Library/include/StonefishCommon.h
+++ b/Library/include/StonefishCommon.h
@@ -31,6 +31,10 @@
 #include <vector>
 #include <stdexcept>
 
+// cmath
+#define _USE_MATH_DEFINES // for Microsoft Visual C++ to get M_PI, M_PI_2 etc.
+#include <cmath>
+
 //Bullet Physics
 #include "btBulletDynamicsCommon.h"
 #include "btBulletCollisionCommon.h"

--- a/Library/include/graphics/OpenGLAtmosphere.h
+++ b/Library/include/graphics/OpenGLAtmosphere.h
@@ -32,7 +32,7 @@
 namespace sf
 {
 	//! A structure representing data of the SunSky UBO (std140 aligned).
-    #pragma pack(1)
+    #pragma pack(push, 1)
 	struct SunSkyUBO
 	{
 		glm::mat4 sunClipSpace[4];      
@@ -43,7 +43,7 @@ namespace sf
         glm::vec3 whitePoint;
         GLfloat atmLengthUnitInMeters;
 	};
-    #pragma pack(0)
+    #pragma pack(pop)
 
     //! An enum definind id's of atmosphere textures.
     enum AtmosphereTextures

--- a/Library/include/graphics/OpenGLContent.h
+++ b/Library/include/graphics/OpenGLContent.h
@@ -53,7 +53,7 @@ namespace sf
         : attach(attachment), target(target), tex(texture), lvl(level), z(zoffset) {}
     };
     
-    #pragma pack(1)
+    #pragma pack(push, 1)
     //! A structure representing data of the Lights UBO (std140 aligned)
     struct LightsUBO
     {
@@ -70,7 +70,7 @@ namespace sf
         glm::vec3 params; //Additional params
         GLuint type;      //Type of velocity field
     };
-    #pragma pack(0)
+    #pragma pack(pop)
 
     //! A structure representing a material shader collection.
     struct MaterialShader

--- a/Library/include/graphics/OpenGLLight.h
+++ b/Library/include/graphics/OpenGLLight.h
@@ -34,9 +34,9 @@ namespace sf
     enum class LightType {POINT, SPOT}; 
     
     //! A structure representing a generic light in the Lights UBO.
-    #pragma pack(1)
+    #pragma pack(push, 1)  
     struct LightUBO {};
-    #pragma pack(0)
+    #pragma pack(pop)
 
     class GLSLShader;
     class OpenGLPipeline;

--- a/Library/include/graphics/OpenGLOcean.h
+++ b/Library/include/graphics/OpenGLOcean.h
@@ -50,7 +50,7 @@ namespace sf
         float t;
     };
 
-    #pragma pack(1)
+    #pragma pack(push, 1)
     //! A structure representing the ocean currents UBO.
     struct OceanCurrentsUBO
     {
@@ -58,7 +58,7 @@ namespace sf
         glm::vec3 gravity;
         GLuint numCurrents;
     };
-    #pragma pack(0)
+    #pragma pack(pop)
 
     class GLSLShader;
 	class OpenGLCamera;

--- a/Library/include/graphics/OpenGLPointLight.h
+++ b/Library/include/graphics/OpenGLPointLight.h
@@ -31,7 +31,7 @@
 namespace sf
 {
     //! A structure representing point light in the Lights UBO.
-    #pragma pack(1)
+    #pragma pack(push, 1)
     struct PointLightUBO : public LightUBO
     {
         glm::vec3 position;
@@ -39,7 +39,8 @@ namespace sf
         glm::vec3 color;
         uint8_t pad[4];
     };
-    #pragma pack(0)
+    #pragma pack(pop)
+
 
     //! A class implementing an OpenGL point light (shadow not supported).
     class OpenGLPointLight : public OpenGLLight

--- a/Library/include/graphics/OpenGLSpotLight.h
+++ b/Library/include/graphics/OpenGLSpotLight.h
@@ -31,7 +31,7 @@
 namespace sf
 {
     //! A structure representing a spot light in the Ligths UBO (std140 aligned).
-    #pragma pack(1)
+    #pragma pack(push, 1)  
     struct SpotLightUBO : public LightUBO
     {
         glm::mat4 clipSpace;
@@ -44,7 +44,7 @@ namespace sf
         glm::vec3 radius; //UV + physical radius
         uint8_t pad[4];
     };
-    #pragma pack(0)
+    #pragma pack(pop)
 
     //! A class implementing an OpenGL spot light with shadow.
     class OpenGLSpotLight : public OpenGLLight

--- a/Library/include/graphics/OpenGLView.h
+++ b/Library/include/graphics/OpenGLView.h
@@ -33,7 +33,7 @@ namespace sf
     //! An enum defining types of views.
     enum class ViewType {CAMERA, TRACKBALL, DEPTH_CAMERA, SONAR};
 
-    #pragma pack(1)
+    #pragma pack(push, 1)
     struct ViewUBO
     {
         glm::mat4 VP;
@@ -41,7 +41,7 @@ namespace sf
         glm::vec3 eye;
         GLfloat pad;
     };
-    #pragma pack(0)
+    #pragma pack(pop)
     
     //! An abstract class representing an OpenGL view.
     class OpenGLView

--- a/Library/include/sensors/Sample.h
+++ b/Library/include/sensors/Sample.h
@@ -42,6 +42,14 @@ namespace sf
          \param index a number specifying the id of the sample
          */
         Sample(unsigned short nDimensions, Scalar* values, bool invalid = false, uint64_t index = 0);
+
+        //! Constructor for initialized sample.
+       /*!
+        \param nDimensions the number of dimensions of the measurement
+        \param invalid a flag to mark if it is and invalid output
+        \param index a number specifying the id of the sample
+        */
+        Sample(unsigned short nDimensions, bool invalid = false, uint64_t index = 0);
         
         //! A copy constructor.
         /*!

--- a/Library/include/utils/SystemUtil.hpp
+++ b/Library/include/utils/SystemUtil.hpp
@@ -40,7 +40,6 @@
     #include <unistd.h>
     #include <Carbon/Carbon.h>
 #else //WINDOWS
-    #include <windows.h>
 #endif
 
 #include "core/GraphicalSimulationApp.h"
@@ -61,14 +60,7 @@ inline int64_t GetTimeInNanoseconds()
     return std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 }
 
-inline void GetCWD(char* buffer, int length)
-{
-#ifdef _MSC_VER
-	GetCurrentDirectory(length, buffer);
-#else
-    getcwd(buffer, length);
-#endif
-}
+void GetCWD(char* buffer, int length);
 
 inline std::string GetShaderPath()
 {
@@ -80,48 +72,11 @@ inline std::string GetDataPath()
     return SimulationApp::getApp()->getDataPath();
 }
 
-inline const char* GetDataPathPrefix(const char* directory)
-{
-    static char dataPathPrefix[PATH_MAX];
-    
-#ifdef __linux__
-
-#elif __APPLE__    
-    CFStringRef dir = CFStringCreateWithCString(CFAllocatorGetDefault(), directory, kCFStringEncodingMacRoman);
-    
-    CFURLRef datafilesURL = CFBundleCopyResourceURL(CFBundleGetMainBundle(), dir, 0, 0);
-    
-    CFURLGetFileSystemRepresentation(datafilesURL, true, reinterpret_cast<UInt8*>(dataPathPrefix), PATH_MAX);
-    
-    if(datafilesURL != NULL)
-        CFRelease(datafilesURL);
-    
-    CFRelease(dir);
-#else //WINDOWS
-    char* envDataPath = 0;
-    
-    // get data path from environment var
-    envDataPath = getenv(DATAPATH_VAR_NAME);
-    
-    // set data path prefix / base directory.  This will
-    // be either from an environment variable, or from
-    // a compiled in default based on original configure
-    // options
-    if (envDataPath != 0)
-        strcpy(dataPathPrefix, envDataPath);
-    else
-        strcpy(dataPathPrefix, CEGUI_SAMPLE_DATAPATH);
-#endif
-    
-    return dataPathPrefix;
-}
+const char* GetDataPathPrefix(const char* directory);
 
 //Extensions
 inline bool CheckForExtension(const char* extensionName)
 {
-#ifdef _MSC_VER
-	return glewIsSupported(extensionName);
-#else
     char* extensions = (char*)glGetString(GL_EXTENSIONS);
     if(extensions == NULL)
         return false;
@@ -137,7 +92,6 @@ inline bool CheckForExtension(const char* extensionName)
         extensions += (n+1);
     }
     return false;
-#endif
 }
 
 //Random functions

--- a/Library/src/entities/solids/Cylinder.cpp
+++ b/Library/src/entities/solids/Cylinder.cpp
@@ -23,6 +23,9 @@
 //  Copyright (c) 2013-2019 Patryk Cieslak. All rights reserved.
 //
 
+#define _USE_MATH_DEFINES // for Microsoft Visual C++
+#include <cmath>
+
 #include "entities/solids/Cylinder.h"
 
 #include "graphics/OpenGLContent.h"

--- a/Library/src/entities/solids/Sphere.cpp
+++ b/Library/src/entities/solids/Sphere.cpp
@@ -23,6 +23,9 @@
 //  Copyright (c) 2013-2019 Patryk Cieslak. All rights reserved.
 //
 
+#define _USE_MATH_DEFINES // for Microsoft Visual C++
+#include <cmath>
+
 #include "entities/solids/Sphere.h"
 
 #include "graphics/OpenGLContent.h"

--- a/Library/src/entities/solids/Torus.cpp
+++ b/Library/src/entities/solids/Torus.cpp
@@ -23,6 +23,10 @@
 //  Copyright (c) 2013-2021 Patryk Cieslak. All rights reserved.
 //
 
+#define _USE_MATH_DEFINES // for Microsoft Visual C++
+#include <cmath>
+
+
 #include "entities/solids/Torus.h"
 
 #include "core/TorusShape.h"

--- a/Library/src/entities/statics/Terrain.cpp
+++ b/Library/src/entities/statics/Terrain.cpp
@@ -47,7 +47,7 @@ Terrain::Terrain(std::string uniqueName, std::string pathToHeightmap, Scalar sca
         heightmap = new GLfloat[w*h];
         for(int i=0; i<h; ++i)
             for(int j=0; j<w; ++j)
-                heightmap[i*w+j] = (1.f - data[i*w+j]/(GLfloat)(__UINT16_MAX__)) * height;
+                heightmap[i*w+j] = (1.f - data[i*w+j]/(GLfloat)(UINT16_MAX)) * height;
         stbi_image_free(data);
     }
     else //8 bit image
@@ -57,7 +57,7 @@ Terrain::Terrain(std::string uniqueName, std::string pathToHeightmap, Scalar sca
         heightmap = new GLfloat[w*h];
         for(int i=0; i<h; ++i)
             for(int j=0; j<w; ++j)
-                heightmap[i*w+j] = (1.f - data[i*w+j]/(GLfloat)(__UINT8_MAX__)) * height;
+                heightmap[i*w+j] = (1.f - data[i*w+j]/(GLfloat)(UINT8_MAX)) * height;
         stbi_image_free(data);
     }
     

--- a/Library/src/graphics/OpenGLCamera.cpp
+++ b/Library/src/graphics/OpenGLCamera.cpp
@@ -119,13 +119,17 @@ OpenGLCamera::OpenGLCamera(GLint x, GLint y, GLint width, GLint height, glm::vec
     //---- Tonemapping ----
     histogramBins = 256;
     histogramRange = glm::vec2(-1.f,11.f);
+#ifdef _MSC_VER
+    GLuint histogram[256];
+#else
     GLuint histogram[histogramBins];
+#endif
     memset(histogram, 0, histogramBins * sizeof(GLuint));
     glGenBuffers(1, &histogramSSBO);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, histogramSSBO);
     glBufferData(GL_SHADER_STORAGE_BUFFER, histogramBins * sizeof(GLuint), histogram, GL_STATIC_DRAW);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-    
+
     GLfloat zero = 0.f;
     exposureTex = OpenGLContent::GenerateTexture(GL_TEXTURE_2D, glm::uvec3(1,1,0), 
                                                  GL_R32F, GL_RED, GL_FLOAT, &zero, FilteringMode::NEAREST, false);

--- a/Library/src/graphics/OpenGLContent.cpp
+++ b/Library/src/graphics/OpenGLContent.cpp
@@ -1972,7 +1972,7 @@ Mesh* OpenGLContent::BuildWing(GLfloat baseChordLength, GLfloat tipChordLength, 
     GLfloat taper = tipChordLength/baseChordLength;
     GLfloat offset = baseChordLength/2.f;
     
-    int div = 20;
+    constexpr int div = 20;
     GLfloat xt[div+1];
     GLfloat yt[div+1];
     for(int i=0; i<=div; ++i)

--- a/Library/src/graphics/OpenGLOceanParticles.cpp
+++ b/Library/src/graphics/OpenGLOceanParticles.cpp
@@ -198,7 +198,11 @@ void OpenGLOceanParticles::Init()
 
     unsigned int seed = (unsigned int)GetTimeInMicroseconds();
     std::mt19937 generator(seed);
+#ifdef _MSC_VER
+    std::uniform_int_distribution<int> dist(-127, 127);
+#else
     std::uniform_int_distribution<int8_t> dist(-127,127);
+#endif
     glm::uvec3 noiseSize3(noiseSize, noiseSize, noiseSize);
     int8_t* noiseData = new int8_t[noiseSize3.x * noiseSize3.y * noiseSize3.z * 4];
     int8_t *ptr = noiseData;

--- a/Library/src/graphics/OpenGLPrinter.cpp
+++ b/Library/src/graphics/OpenGLPrinter.cpp
@@ -163,6 +163,16 @@ void OpenGLPrinter::Print(const std::string& text, glm::vec4 color, GLuint x, GL
     if(!initialized)
         return;
     
+#ifdef _MSC_VER
+    struct Point
+    {
+        GLfloat x;
+        GLfloat y;
+        GLfloat s;
+        GLfloat t;
+    };
+    Point* coords = new Point[6 * text.length()];
+#else
     struct Point
     {
         GLfloat x;
@@ -170,7 +180,7 @@ void OpenGLPrinter::Print(const std::string& text, glm::vec4 color, GLuint x, GL
         GLfloat s;
         GLfloat t;
     } coords[6 * text.length()];
-    
+#endif
     memset(coords, 0, sizeof coords);
     
     unsigned int n = 0;
@@ -209,13 +219,13 @@ void OpenGLPrinter::Print(const std::string& text, glm::vec4 color, GLuint x, GL
         
         if(!w || !h)
             continue;
-        
-        coords[n++] = (Point){x2, -y2,     ch.offset, 0};
-        coords[n++] = (Point){x2+w, -y2,   ch.offset + ch.size.x/texWidth, 0};
-        coords[n++] = (Point){x2, -y2-h,   ch.offset, ch.size.y/texHeight};
-        coords[n++] = (Point){x2+w, -y2,   ch.offset + ch.size.x/texWidth, 0};
-        coords[n++] = (Point){x2, -y2-h,   ch.offset, ch.size.y/texHeight};
-        coords[n++] = (Point){x2+w, -y2-h, ch.offset + ch.size.x/texWidth, ch.size.y/texHeight};
+
+        coords[n++] = Point({ x2, -y2,     ch.offset, 0 });
+        coords[n++] = Point({ x2 + w, -y2,   ch.offset + ch.size.x / texWidth, 0 });
+        coords[n++] = Point({ x2, -y2 - h,   ch.offset, ch.size.y / texHeight });
+        coords[n++] = Point({ x2 + w, -y2,   ch.offset + ch.size.x / texWidth, 0 });
+        coords[n++] = Point({ x2, -y2 - h,   ch.offset, ch.size.y / texHeight });
+        coords[n++] = Point({ x2 + w, -y2 - h, ch.offset + ch.size.x / texWidth, ch.size.y / texHeight });
     }
     
     glBindBuffer(GL_ARRAY_BUFFER, fontVBO);
@@ -235,6 +245,9 @@ void OpenGLPrinter::Print(const std::string& text, glm::vec4 color, GLuint x, GL
         OpenGLState::UnbindTexture(TEX_GUI1);
         OpenGLState::UseProgram(0);
     }
+#ifdef _MSC_VER
+    delete[] coords;
+#endif
 }
 
 GLuint OpenGLPrinter::TextLength(const std::string& text)

--- a/Library/src/sensors/Sample.cpp
+++ b/Library/src/sensors/Sample.cpp
@@ -43,6 +43,18 @@ Sample::Sample(unsigned short nDimensions, Scalar* values, bool invalid, uint64_
         timestamp = SimulationApp::getApp()->getSimulationManager()->getSimulationTime();
 }
 
+Sample::Sample(unsigned short nDimensions, bool invalid, uint64_t index)
+{
+    nDim = nDimensions > 0 ? nDimensions : 1;
+    data = new Scalar[nDim];
+    std::memset(data, 0, sizeof(Scalar) * nDim);
+    id = index;
+    if (invalid)
+        timestamp = Scalar(-1);
+    else
+        timestamp = SimulationApp::getApp()->getSimulationManager()->getSimulationTime();
+}
+
 Sample::Sample(const Sample& other, uint64_t index)
 {
     timestamp = other.timestamp;

--- a/Library/src/sensors/ScalarSensor.cpp
+++ b/Library/src/sensors/ScalarSensor.cpp
@@ -52,10 +52,7 @@ Sample ScalarSensor::getLastSample()
         return Sample(*history.back());
     else
     {
-        unsigned short chs = getNumOfChannels();
-        Scalar values[chs];
-        memset(values, 0, sizeof(Scalar) * chs);
-        return Sample(chs, values, true);
+        return Sample(getNumOfChannels(), true);
     }
 }
 

--- a/Library/src/utils/ScientificFileUtil.cpp
+++ b/Library/src/utils/ScientificFileUtil.cpp
@@ -158,7 +158,11 @@ ScientificData* LoadOctaveData(const std::string& path)
         if(file.eof())
             break;
         
+#ifdef _MSC_VER
+        char cname[_MAX_PATH];
+#else   
         char cname[nameLen + 1];
+#endif
         cname[nameLen] = '\0';
         file.read(cname, nameLen);
         
@@ -211,7 +215,11 @@ ScientificData* LoadOctaveData(const std::string& path)
             int32_t typeLen = 0;
             file.read(reinterpret_cast<char*>(&typeLen), 4);
             
+#ifdef _MSC_VER
+            char typeName[_MAX_PATH];
+#else 
             char typeName[typeLen + 1];
+#endif
             typeName[typeLen] = '\0';
             file.read(typeName, typeLen);
             

--- a/Library/src/utils/SystemUtil.cpp
+++ b/Library/src/utils/SystemUtil.cpp
@@ -1,0 +1,82 @@
+/*    
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  SystemUtil.cpp
+//  Stonefish
+//
+//  Created by Patryk Cieslak on 8/24/13.
+//  Copyright (c) 2013-2018 Patryk Cieslak. All rights reserved.
+//
+
+#include "utils/SystemUtil.hpp"
+
+#ifdef WIN32
+    #define WINDOWS_LEAN_AND_MEAN
+    #include <windows.h>
+    #define PATH_MAX                MAX_PATH
+#endif
+
+namespace sf
+{
+
+    void GetCWD(char* buffer, int length)
+    {
+    #ifdef _MSC_VER
+        GetCurrentDirectory(length, buffer);
+    #else
+        getcwd(buffer, length);
+    #endif
+    }
+
+    const char* GetDataPathPrefix(const char* directory)
+    {
+        static char dataPathPrefix[PATH_MAX];
+        
+    #ifdef __linux__
+
+    #elif __APPLE__    
+        CFStringRef dir = CFStringCreateWithCString(CFAllocatorGetDefault(), directory, kCFStringEncodingMacRoman);
+        
+        CFURLRef datafilesURL = CFBundleCopyResourceURL(CFBundleGetMainBundle(), dir, 0, 0);
+        
+        CFURLGetFileSystemRepresentation(datafilesURL, true, reinterpret_cast<UInt8*>(dataPathPrefix), PATH_MAX);
+        
+        if(datafilesURL != NULL)
+            CFRelease(datafilesURL);
+        
+        CFRelease(dir);
+    #else //WINDOWS
+        char* envDataPath = 0;
+        
+        // get data path from environment var
+        envDataPath = getenv("STONEFISH_DATA_PATH");
+        
+        // set data path prefix / base directory.  This will
+        // be either from an environment variable, or from
+        // a compiled in default based on original configure
+        // options
+        if (envDataPath != 0)
+            strcpy(dataPathPrefix, envDataPath);
+        else
+            strcpy(dataPathPrefix, "CEGUI_SAMPLE_DATAPATH");
+    #endif
+        
+        return dataPathPrefix;
+    }
+
+}

--- a/Tests/FallingTest/main.cpp
+++ b/Tests/FallingTest/main.cpp
@@ -26,7 +26,7 @@
 #include "FallingTestApp.h"
 #include "FallingTestManager.h"
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     sf::RenderSettings s;
     s.windowW = 1200;

--- a/Tests/FloatingTest/main.cpp
+++ b/Tests/FloatingTest/main.cpp
@@ -26,7 +26,7 @@
 #include <core/GraphicalSimulationApp.h>
 #include "FloatingTestManager.h"
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     sf::RenderSettings s;
     s.windowW = 1200;

--- a/Tests/FlyingTest/main.cpp
+++ b/Tests/FlyingTest/main.cpp
@@ -26,7 +26,7 @@
 #include <core/GraphicalSimulationApp.h>
 #include "FlyingTestManager.h"
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     sf::RenderSettings s;
     s.windowW = 1200;

--- a/Tests/JointsTest/main.cpp
+++ b/Tests/JointsTest/main.cpp
@@ -27,7 +27,7 @@
 #include "JointsTestManager.h"
 #include "JointsTestApp.h"
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     sf::RenderSettings s;
     s.windowW = 800;

--- a/Tests/SlidingTest/main.cpp
+++ b/Tests/SlidingTest/main.cpp
@@ -26,7 +26,7 @@
 #include "SlidingTestApp.h"
 #include "SlidingTestManager.h"
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     sf::RenderSettings s;
     s.windowW = 1200;

--- a/Tests/UnderwaterTest/main.cpp
+++ b/Tests/UnderwaterTest/main.cpp
@@ -27,7 +27,7 @@
 #include "UnderwaterTestManager.h"
 #include <cfenv>
 
-int main(int argc, const char * argv[])
+int main(int argc, char * argv[])
 {
     //feenableexcept(FE_ALL_EXCEPT & ~FE_INEXACT);
     //feenableexcept(FE_INVALID | FE_OVERFLOW);


### PR DESCRIPTION
- moved functions to SystemUtil.cpp to not include windows.h in other c++ files (preprocessor names collide)
- replaced pragmas pack(1)...pack(0) with pack(push, 1)...pack(pop) (pack(0) does not reset the alignment)
- variabe-length arrays are not supported
- _USE_MATH_DEFINES must be set before cmath inclusion to get macros like M_PI, M_PI_2, ...
- Tests: SDL requires "int main(int argc, char * argv[])" instead of "int main(int argc, const char * argv[])"

Right now all programs are running, but GUI elements (like checkboxes) do not show text