### PR TITLE
Ensure short path angular velocity on trajectory interpolation

### DIFF
--- a/Library/include/entities/animation/Trajectory.h
+++ b/Library/include/entities/animation/Trajectory.h
@@ -74,6 +74,8 @@ namespace sf
         //! A method returning the current playback iteration.
         unsigned int getPlaybackIteration() const;
 
+        static void calculateVelocityShortestPath(const Transform &transform0, const Transform &transform1, Scalar timeStep, Vector3 &linVel, Vector3 &angVel);
+    
     protected:
         PlaybackMode playMode;
         Scalar playTime;

--- a/Library/src/entities/animation/CRTrajectory.cpp
+++ b/Library/src/entities/animation/CRTrajectory.cpp
@@ -98,7 +98,7 @@ void CRTrajectory::Interpolate()
         //Angular quantities
         Vector3 dummy;
         interpTrans.setRotation(slerp(T1.getRotation(), T2.getRotation(), (playTime-t1)/(t2-t1)));
-        btTransformUtil::calculateVelocity(T1, T2, t2-t1, dummy, interpAngVel);
+        calculateVelocityShortestPath(T1, T2, t2-t1, dummy, interpAngVel);
     }
 }
 

--- a/Library/src/entities/animation/PWLTrajectory.cpp
+++ b/Library/src/entities/animation/PWLTrajectory.cpp
@@ -82,16 +82,16 @@ void PWLTrajectory::Interpolate()
     {
         interpTrans = it->T;
         if(it == points.begin()) //Time = 0
-            btTransformUtil::calculateVelocity(it->T, (it+1)->T, (it+1)->t, interpVel, interpAngVel);
+            calculateVelocityShortestPath(it->T, (it+1)->T, (it+1)->t, interpVel, interpAngVel);
         else
-            btTransformUtil::calculateVelocity((it-1)->T, it->T, it->t-(it-1)->t, interpVel, interpAngVel);
+            calculateVelocityShortestPath((it-1)->T, it->T, it->t-(it-1)->t, interpVel, interpAngVel);
     }
     else
     {
         Scalar alpha = (playTime - (it-1)->t)/(it->t - (it-1)->t);
         interpTrans.setOrigin(lerp((it-1)->T.getOrigin(), it->T.getOrigin(), alpha));
         interpTrans.setRotation(slerp((it-1)->T.getRotation(), it->T.getRotation(), alpha));
-        btTransformUtil::calculateVelocity((it-1)->T, it->T, it->t-(it-1)->t, interpVel, interpAngVel);
+        calculateVelocityShortestPath((it-1)->T, it->T, it->t-(it-1)->t, interpVel, interpAngVel);
     }
 }
 


### PR DESCRIPTION
The rotation path between two quaternions may turn either the "short way" (less than 180°) or the "long way" (more than 180°). Long paths can be prevented by negating one end if the dot product, cos Ω, is negative, thus ensuring that −90° ≤ Ω ≤ 90°. See
https://en.wikipedia.org/wiki/Slerp