### PR TITLE
New thruster with configurable rotor dynamics and thrust conversions

### DIFF
--- a/Library/include/actuators/Actuator.h
+++ b/Library/include/actuators/Actuator.h
@@ -34,7 +34,7 @@ namespace sf
     struct Renderable;
     
     //! An enum designating a type of the actuator.
-    enum class ActuatorType {MOTOR, SERVO, PROPELLER, THRUSTER, VBS, LIGHT, RUDDER, SUCTION_CUP, PUSH, SIMPLE_THRUSTER};
+    enum class ActuatorType {MOTOR, SERVO, PROPELLER, THRUSTER, VBS, LIGHT, RUDDER, SUCTION_CUP, PUSH, SIMPLE_THRUSTER, THRUSTER_ENGINE};
     
     //! An abstract class representing any actuator.
     class Actuator

--- a/Library/include/actuators/Actuator.h
+++ b/Library/include/actuators/Actuator.h
@@ -34,7 +34,7 @@ namespace sf
     struct Renderable;
     
     //! An enum designating a type of the actuator.
-    enum class ActuatorType {MOTOR, SERVO, PROPELLER, THRUSTER, VBS, LIGHT, RUDDER, SUCTION_CUP, PUSH, SIMPLE_THRUSTER, THRUSTER_ENGINE};
+    enum class ActuatorType {MOTOR, SERVO, PROPELLER, THRUSTER, VBS, LIGHT, RUDDER, SUCTION_CUP, PUSH, SIMPLE_THRUSTER, CONFIGURABLE_THRUSTER};
     
     //! An abstract class representing any actuator.
     class Actuator

--- a/Library/include/actuators/ConfigurableThruster.h
+++ b/Library/include/actuators/ConfigurableThruster.h
@@ -1,0 +1,119 @@
+/*
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  ConfigurableThruster.h
+//  Stonefish
+//
+//  Created by Roger Pi on 03/06/2024
+//  Copyright (c) 2024 Roger Pi. All rights reserved.
+//
+
+#pragma once
+
+#include "actuators/LinkActuator.h"
+#include "ConfigurableThrusterModels.h"
+
+namespace sf
+{
+//! A class representing a thruster.
+class ConfigurableThruster : public LinkActuator
+{
+public:
+  //! A constructor.
+  /*!
+   \param uniqueName a name for the thruster
+   \param propeller a pointer to a rigid body representing the propeller
+   \param diameter the diameter of the propeller [m]
+   \param thrustCoeff the thrust coefficient (forward and backward)
+   \param torqueCoeff the torque coefficient
+   \param maxRPM the maximum rotational speed of the thruster [rpm]
+   \param rightHand a flag to indicate if the propeller is right hand (clockwise rotation)
+   \param inverted a flag to indicate if the setpoint is inverted (positive value results in backward force)
+  */
+  ConfigurableThruster(std::string uniqueName, SolidEntity* propeller,                      //
+                 std::shared_ptr<rm::RotorDynamics> rotorDynamics,        //
+                 std::shared_ptr<tm::ThrustModel> thrustConversion,  //
+                 bool rightHand, bool inverted = false);
+
+  //! A destructor.
+  ~ConfigurableThruster();
+
+  //! A method used to update the internal state of the thruster.
+  /*!
+   \param dt a time step of the simulation [s]
+   */
+  void Update(Scalar dt);
+
+  //! A method implementing the rendering of the thruster.
+  std::vector<Renderable> Render();
+
+  //! A method setting the new value of the thruster speed setpoint.
+  /*!
+   \param s the desired speed of the thruster as fraction <0,1>
+   */
+  void setSetpoint(Scalar s);
+
+  //! A method used to set the velocity limits.
+  void setVelocityLimits(Scalar lower, Scalar upper);
+
+  //! A method returning the current setpoint.
+  Scalar getSetpoint() const;
+
+  //! A method returning the generated thrust.
+  Scalar getThrust() const;
+
+  //! A method returning the induced torque.
+  Scalar getTorque() const;
+
+  //! A method returning the angular position of the propeller [rad]
+  Scalar getAngle() const;
+
+  //! A method returning the angular velocity of the propeller [rad/s]
+  Scalar getOmega() const;
+
+  //! A method returning the maximum speed of the thruster [RPM].
+  Scalar getMaxRPM() const;
+
+  //! A method informing if the propeller is right-handed.
+  bool isPropellerRight() const;
+
+  //! A method returning the type of the actuator.
+  ActuatorType getType() const;
+
+private:
+  void WatchdogTimeout() override;
+
+  // Params
+  SolidEntity* prop_;
+  bool RH_;
+  bool inv_;
+  std::pair<Scalar, Scalar> limits_;
+
+  // States
+  Scalar theta_;   // [rad]. Angle of the propeller
+  Scalar omega_;   // [rad/s]. Angular velocity of the propeller
+  Scalar thrust_;  // [N]. Generated thrust
+  Scalar torque_;  // [Nm]. Induced torque @TODO
+
+  Scalar setpoint_;  // [-]. Desired speed of the propeller
+
+  // Dynamics
+  std::shared_ptr<rm::RotorDynamics> rotorModel_;
+  std::shared_ptr<tm::ThrustModel> thrustModel_;
+};
+}  // namespace sf

--- a/Library/include/actuators/ConfigurableThruster.h
+++ b/Library/include/actuators/ConfigurableThruster.h
@@ -38,17 +38,15 @@ public:
   /*!
    \param uniqueName a name for the thruster
    \param propeller a pointer to a rigid body representing the propeller
-   \param diameter the diameter of the propeller [m]
-   \param thrustCoeff the thrust coefficient (forward and backward)
-   \param torqueCoeff the torque coefficient
-   \param maxRPM the maximum rotational speed of the thruster [rpm]
+   \param rotorDynamics a pointer to the rotor dynamics model
+   \param thrustConversion a pointer to the thrust conversion model
    \param rightHand a flag to indicate if the propeller is right hand (clockwise rotation)
    \param inverted a flag to indicate if the setpoint is inverted (positive value results in backward force)
   */
-  ConfigurableThruster(std::string uniqueName, SolidEntity* propeller,                      //
-                 std::shared_ptr<rm::RotorDynamics> rotorDynamics,        //
-                 std::shared_ptr<tm::ThrustModel> thrustConversion,  //
-                 bool rightHand, bool inverted = false);
+  ConfigurableThruster(std::string uniqueName, SolidEntity* propeller,     //
+                       std::shared_ptr<td::RotorDynamics> rotorDynamics,   //
+                       std::shared_ptr<td::ThrustModel> thrustConversion,  //
+                       bool rightHand, bool inverted = false);
 
   //! A destructor.
   ~ConfigurableThruster();
@@ -113,7 +111,7 @@ private:
   Scalar setpoint_;  // [-]. Desired speed of the propeller
 
   // Dynamics
-  std::shared_ptr<rm::RotorDynamics> rotorModel_;
-  std::shared_ptr<tm::ThrustModel> thrustModel_;
+  std::shared_ptr<td::RotorDynamics> rotorModel_;
+  std::shared_ptr<td::ThrustModel> thrustModel_;
 };
 }  // namespace sf

--- a/Library/include/actuators/ConfigurableThrusterModels.h
+++ b/Library/include/actuators/ConfigurableThrusterModels.h
@@ -27,6 +27,7 @@
 
 #include "StonefishCommon.h"
 #include <memory>
+#include <iostream>
 
 namespace sf
 {
@@ -36,8 +37,8 @@ namespace td // thrust dynamics
 class RotorDynamics
 {
 protected:
-  Scalar last_output_;
-  Scalar last_time_;
+  Scalar last_output_ = 0.0;
+  Scalar last_time_ = 0.0;
 
 public:
   virtual Scalar f(Scalar time, Scalar sp) = 0;

--- a/Library/include/actuators/ConfigurableThrusterModels.h
+++ b/Library/include/actuators/ConfigurableThrusterModels.h
@@ -1,0 +1,206 @@
+/*
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  ConfigurableThrusterModels.h
+//  Stonefish
+//
+//  Created by Roger Pi on 03/06/2024
+//  Copyright (c) 2024 Stonefish. All rights reserved.
+//
+
+#pragma once
+
+#include "StonefishCommon.h"
+#include <memory>
+
+namespace sf
+{
+namespace rm
+{
+
+class RotorDynamics
+{
+protected:
+  Scalar last_output_;
+  Scalar last_time_;
+
+public:
+  virtual Scalar f(Scalar time, Scalar sp) = 0;
+
+  Scalar getLastOutput() const
+  {
+    return last_output_;
+  }
+  Scalar getLastTime() const
+  {
+    return last_time_;
+  }
+};
+
+// Here we will implement several dynamic models
+
+class ZeroOrder : public RotorDynamics
+{
+public:
+  // implement a Zero Order model
+
+  Scalar f(Scalar time, Scalar sp)
+  {
+    return sp;
+  }
+};
+
+class FirstOrder : public RotorDynamics
+{
+private:
+  Scalar tau_;
+
+public:
+  FirstOrder(Scalar tau) : tau_(tau)
+  {
+  }
+
+  // implement a First Order model
+
+  Scalar f(Scalar time, Scalar sp)
+  {
+    Scalar dt = time - last_time_;
+    Scalar alpha = dt / tau_;
+
+    Scalar output = alpha * sp + (1 - alpha) * last_output_;
+
+    last_output_ = output;
+    last_time_ = time;
+
+    return output;
+  }
+};
+
+class Yoerger : public RotorDynamics
+{
+private:
+  Scalar alpha_;
+  Scalar beta_;
+
+public:
+  Yoerger(Scalar alpha, Scalar beta) : alpha_(alpha), beta_(beta)
+  {
+  }
+
+  Scalar f(Scalar time, Scalar sp)
+  {
+    Scalar dt = time - last_time_;
+
+    //  state += dt*(beta*_cmd - alpha*state*std::abs(state));
+
+    Scalar output = last_output_ + dt * (beta_ * sp - (alpha_ * last_output_ * std::abs(last_output_)));
+
+    last_output_ = output;
+    last_time_ = time;
+
+    return output;
+  }
+};
+
+class Bessa : public RotorDynamics
+{
+private:
+  Scalar Jmsp_;
+  Scalar Kv1_;
+  Scalar Kv2_;
+  Scalar Kt_;
+  Scalar Rm_;
+
+public:
+  Bessa(Scalar Jmsp, Scalar Kv1, Scalar Kv2, Scalar Kt, Scalar Rm) : Jmsp_(Jmsp), Kv1_(Kv1), Kv2_(Kv2), Kt_(Kt), Rm_(Rm)
+  {
+  }
+
+  Scalar f(Scalar time, Scalar sp)
+  {
+    Scalar dt = time - last_time_;
+
+    Scalar output = last_output_ +
+                    dt * (sp * Kt_ / Rm_ - Kv1_ * last_output_ - Kv2_ * last_output_ * std::abs(last_output_)) / Jmsp_;
+
+    last_output_ = output;
+    last_time_ = time;
+
+    return output;
+  }
+};
+
+}  // namespace rm
+
+namespace tm
+{
+
+class ThrustModel
+{
+public:
+  virtual Scalar f(Scalar val) = 0;
+};
+
+class BasicThrustConversion : public ThrustModel
+{
+protected:
+  Scalar cb_;
+
+public:
+  BasicThrustConversion(Scalar cb) : cb_(cb)
+  {
+  }
+
+  Scalar f(Scalar val) override
+  {
+    return cb_ * val * std::abs(val);
+  }
+};
+
+class DeadBandConversion : public ThrustModel
+{
+protected:
+  Scalar c_l_;
+  Scalar c_r_;
+  Scalar d_l_;
+  Scalar d_r_;
+
+public:
+  DeadBandConversion(Scalar c_l, Scalar c_r, Scalar d_l, Scalar d_r) : c_l_(c_l), c_r_(c_r), d_l_(d_l), d_r_(d_r)
+  {
+  }
+
+  Scalar f(Scalar val) override
+  {
+    Scalar vv = val * std::abs(val);
+    if (vv < d_l_)
+    {
+      return c_l_ * (vv - d_l_);
+    }
+    else if (vv > d_r_)
+    {
+      return c_r_ * (vv - d_r_);
+    }
+    else
+    {
+      return 0;
+    }
+  }
+};
+}  // namespace tm
+}  // namespace sf

--- a/Library/include/actuators/SimpleThruster.h
+++ b/Library/include/actuators/SimpleThruster.h
@@ -64,6 +64,9 @@ namespace sf
         //! A method used to set the thrust limits.
         void setThrustLimits(Scalar lower, Scalar upper);
 
+        //! A method returning the requested setpoint.
+        Scalar getThrustSetpoint() const;
+
         //! A method returning the generated thrust.
         Scalar getThrust() const;
 

--- a/Library/src/actuators/ConfigurableThruster.cpp
+++ b/Library/src/actuators/ConfigurableThruster.cpp
@@ -86,8 +86,6 @@ void ConfigurableThruster::setSetpoint(Scalar s)
   }
 
   ResetWatchdog();
-
-  cInfo("ConfigurableThruster::setSetpoint: %lf", setpoint_);
 }
 
 void ConfigurableThruster::setVelocityLimits(Scalar lower, Scalar upper)

--- a/Library/src/actuators/ConfigurableThruster.cpp
+++ b/Library/src/actuators/ConfigurableThruster.cpp
@@ -42,8 +42,8 @@ namespace sf
 {
 
 ConfigurableThruster::ConfigurableThruster(std::string uniqueName, SolidEntity* propeller,     //
-                                           std::shared_ptr<rm::RotorDynamics> rotorDynamics,   //
-                                           std::shared_ptr<tm::ThrustModel> thrustConversion,  //
+                                           std::shared_ptr<td::RotorDynamics> rotorDynamics,   //
+                                           std::shared_ptr<td::ThrustModel> thrustConversion,  //
                                            bool rightHand, bool inverted)
   : LinkActuator(uniqueName)
   , RH_(rightHand)
@@ -70,7 +70,7 @@ ConfigurableThruster::~ConfigurableThruster()
 
 ActuatorType ConfigurableThruster::getType() const
 {
-  return ActuatorType::SIMPLE_THRUSTER;  //@TODO: ActuatorType::CONFIGURABLE_THRUSTER?
+  return ActuatorType::CONFIGURABLE_THRUSTER;
 }
 
 void ConfigurableThruster::setSetpoint(Scalar s)
@@ -129,11 +129,9 @@ void ConfigurableThruster::Update(Scalar dt)
     return;  // No attachment, no action
 
   // Update rotation & angular velocity
-  if (!btFuzzyZero(setpoint_))
-  {
-    omega_ = rotorModel_->f(rotorModel_->getLastTime() + dt, setpoint_);
-    omega_ = RH_ ? omega_ : -omega_;
-  }
+  omega_ = rotorModel_->f(rotorModel_->getLastTime() + dt, setpoint_);
+  omega_ = RH_ ? omega_ : -omega_;
+  
   theta_ += omega_ * dt;  // Just for animation
 
   // Update Thrust

--- a/Library/src/actuators/ConfigurableThruster.cpp
+++ b/Library/src/actuators/ConfigurableThruster.cpp
@@ -1,0 +1,199 @@
+/*
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  ConfigurableThruster.cpp
+//  Stonefish
+//
+//  Created by Roger Pi on 03/06/2024
+//  Copyright (c) 2024 Roger Pi. All rights reserved.
+//
+
+#include "actuators/ConfigurableThruster.h"
+
+#include "core/SimulationApp.h"
+#include "core/SimulationManager.h"
+#include "graphics/GLSLShader.h"
+#include "graphics/OpenGLContent.h"
+#include "entities/SolidEntity.h"
+
+// clamp implementation, to be removed when C++17 is available
+template <class T>
+const T& clamp(const T& v, const T& lo, const T& hi)
+{
+  return std::min(hi, std::max(lo, v));
+}
+
+namespace sf
+{
+
+ConfigurableThruster::ConfigurableThruster(std::string uniqueName, SolidEntity* propeller,     //
+                                           std::shared_ptr<rm::RotorDynamics> rotorDynamics,   //
+                                           std::shared_ptr<tm::ThrustModel> thrustConversion,  //
+                                           bool rightHand, bool inverted)
+  : LinkActuator(uniqueName)
+  , RH_(rightHand)
+  , inv_(inverted)
+  , theta_(Scalar(0))
+  , omega_(Scalar(0))
+  , thrust_(Scalar(0))
+  , torque_(Scalar(0))
+  , setpoint_(Scalar(0))
+  , rotorModel_(rotorDynamics)
+  , thrustModel_(thrustConversion)
+{
+  setVelocityLimits(1, -1);  // No limits
+
+  prop_ = propeller;
+  prop_->BuildGraphicalObject();
+}
+
+ConfigurableThruster::~ConfigurableThruster()
+{
+  if (prop_ != nullptr)
+    delete prop_;
+}
+
+ActuatorType ConfigurableThruster::getType() const
+{
+  return ActuatorType::SIMPLE_THRUSTER;  //@TODO: ActuatorType::CONFIGURABLE_THRUSTER?
+}
+
+void ConfigurableThruster::setSetpoint(Scalar s)
+{
+  setpoint_ = s;
+
+  if (limits_.second > limits_.first)  // Limitted
+    setpoint_ = clamp(setpoint_, limits_.first, limits_.second);
+
+  if (inv_)
+  {
+    setpoint_ *= Scalar(-1);
+  }
+
+  ResetWatchdog();
+
+  cInfo("ConfigurableThruster::setSetpoint: %lf", setpoint_);
+}
+
+void ConfigurableThruster::setVelocityLimits(Scalar lower, Scalar upper)
+{
+  limits_.first = lower;
+  limits_.second = upper;
+}
+
+Scalar ConfigurableThruster::getSetpoint() const
+{
+  return inv_ ? -setpoint_ : setpoint_;
+}
+
+Scalar ConfigurableThruster::getAngle() const
+{
+  return theta_;
+}
+
+Scalar ConfigurableThruster::getOmega() const
+{
+  return omega_;
+}
+
+Scalar ConfigurableThruster::getThrust() const
+{
+  return thrust_;
+}
+
+Scalar ConfigurableThruster::getTorque() const
+{
+  return torque_;
+}
+
+void ConfigurableThruster::Update(Scalar dt)
+{
+  Actuator::Update(dt);
+
+  if (attach == nullptr)
+    return;  // No attachment, no action
+
+  // Update rotation & angular velocity
+  if (!btFuzzyZero(setpoint_))
+  {
+    omega_ = rotorModel_->f(rotorModel_->getLastTime() + dt, setpoint_);
+    omega_ = RH_ ? omega_ : -omega_;
+  }
+  theta_ += omega_ * dt;  // Just for animation
+
+  // Update Thrust
+  thrust_ = thrustModel_->f(omega_);
+  torque_ = Scalar(0);  // @TODO
+
+  // Get transforms
+  Transform solidTrans = attach->getCGTransform();
+  Transform thrustTrans = attach->getOTransform() * o2a;
+
+  // Calculate thrust
+  Ocean* ocn = SimulationApp::getApp()->getSimulationManager()->getOcean();
+  if (ocn != nullptr && ocn->IsInsideFluid(thrustTrans.getOrigin()))
+  {
+    // Apply forces and torques
+    Vector3 thrustV(thrust_, 0, 0);
+    Vector3 torqueV(torque_, 0, 0);
+    attach->ApplyCentralForce(thrustTrans.getBasis() * thrustV);
+    attach->ApplyTorque((thrustTrans.getOrigin() - solidTrans.getOrigin()).cross(thrustTrans.getBasis() * thrustV));
+    attach->ApplyTorque(thrustTrans.getBasis() * torqueV);
+  }
+  else
+  {
+    thrust_ = Scalar(0);
+    torque_ = Scalar(0);
+  }
+}
+
+std::vector<Renderable> ConfigurableThruster::Render()
+{
+  Transform thrustTrans = Transform::getIdentity();
+  if (attach != nullptr)
+    thrustTrans = attach->getOTransform() * o2a;
+  else
+    LinkActuator::Render();
+
+  // Rotate propeller
+  thrustTrans *= Transform(Quaternion(0, 0, theta_), Vector3(0, 0, 0));
+
+  // Add renderable
+  std::vector<Renderable> items(0);
+  Renderable item;
+  item.type = RenderableType::SOLID;
+  item.materialName = prop_->getMaterial().name;
+  item.objectId = prop_->getGraphicalObject();
+  item.lookId = dm == DisplayMode::GRAPHICAL ? prop_->getLook() : -1;
+  item.model = glMatrixFromTransform(thrustTrans);
+  items.push_back(item);
+
+  item.type = RenderableType::ACTUATOR_LINES;
+  item.points.push_back(glm::vec3(0, 0, 0));
+  item.points.push_back(glm::vec3(0.1f * thrust_, 0, 0));
+  items.push_back(item);
+
+  return items;
+}
+
+void ConfigurableThruster::WatchdogTimeout()
+{
+  setSetpoint(Scalar(0));
+}
+
+}  // namespace sf

--- a/Library/src/actuators/SimpleThruster.cpp
+++ b/Library/src/actuators/SimpleThruster.cpp
@@ -85,6 +85,11 @@ Scalar SimpleThruster::getAngle() const
     return theta;
 }
 
+Scalar SimpleThruster::getThrustSetpoint() const
+{
+    return sThrust;
+}
+
 Scalar SimpleThruster::getThrust() const
 {
     return thrust;

--- a/Library/src/core/ScenarioParser.cpp
+++ b/Library/src/core/ScenarioParser.cpp
@@ -73,6 +73,8 @@
 #include "actuators/Propeller.h"
 #include "actuators/Rudder.h"
 #include "actuators/SimpleThruster.h"
+#include "actuators/ConfigurableThruster.h"
+#include "actuators/ConfigurableThrusterModels.h"
 #include "actuators/Thruster.h"
 #include "actuators/VariableBuoyancy.h"
 #include "actuators/SuctionCup.h"
@@ -83,6 +85,7 @@
 #include "graphics/OpenGLDataStructs.h"
 #include "utils/SystemUtil.hpp"
 #include "tinyexpr.h"
+#include <sstream>
 
 namespace sf
 {
@@ -2238,6 +2241,7 @@ bool ScenarioParser::ParseActuator(XMLElement* element, Robot* robot)
         //Link actuators
         case ActuatorType::PUSH:
         case ActuatorType::SIMPLE_THRUSTER:
+        case ActuatorType::CONFIGURABLE_THRUSTER:
         case ActuatorType::THRUSTER:
         case ActuatorType::PROPELLER:
         case ActuatorType::RUDDER:
@@ -2491,6 +2495,268 @@ Actuator* ScenarioParser::ParseActuator(XMLElement* element, const std::string& 
             push = new Push(actuatorName, false);
         return push;
     }
+    else if (typeStr == "configurable_thruster")
+    {
+        const char* propFile = nullptr;
+        const char* mat = nullptr;
+        const char* look = nullptr;
+        Scalar propScale;
+        bool rightHand;
+
+        if ((item = element->FirstChildElement("propeller")) == nullptr ||
+            item->QueryAttribute("right", &rightHand) != XML_SUCCESS)
+        {
+        log.Print(MessageType::ERROR, "Propeller definition of actuator '%s' missing!", actuatorName.c_str());
+        return nullptr;
+        }
+        XMLElement* item2;
+        if ((item2 = item->FirstChildElement("mesh")) == nullptr ||
+            item2->QueryStringAttribute("filename", &propFile) != XML_SUCCESS)
+        {
+        log.Print(MessageType::ERROR, "Propeller mesh path of actuator '%s' missing!", actuatorName.c_str());
+        return nullptr;
+        }
+        if (item2->QueryAttribute("scale", &propScale) != XML_SUCCESS)
+        propScale = Scalar(1);
+        if ((item2 = item->FirstChildElement("material")) == nullptr ||
+            item2->QueryStringAttribute("name", &mat) != XML_SUCCESS)
+        {
+        log.Print(MessageType::ERROR, "Propeller material of actuator '%s' missing!", actuatorName.c_str());
+        return nullptr;
+        }
+        std::string lookStr = "";
+        if ((item2 = item->FirstChildElement("look")) != nullptr)
+        {
+        item2->QueryStringAttribute("name", &look);
+        lookStr = std::string(look);
+        }
+
+        BodyPhysicsSettings phy;
+        phy.collisions = false;
+        phy.buoyancy = false;
+
+        phy.mode = BodyPhysicsMode::SUBMERGED;
+        Polyhedron* prop = new Polyhedron(actuatorName + "/Propeller", phy, GetFullPath(std::string(propFile)), propScale,
+                                        I4(), std::string(mat), lookStr);
+
+        bool has_inverted = false;
+        bool has_limits = false;
+
+        std::pair<Scalar, Scalar> vel_limits = std::make_pair(1, -1);  // lower, upper
+        bool inverted = false;
+
+        if ((item = element->FirstChildElement("specs")) != nullptr)
+        {
+        if (item->QueryAttribute("inverted", &inverted) != XML_SUCCESS)
+            has_inverted = false;
+
+        if (item->QueryAttribute("lower_velocity_limit", &vel_limits.first) == XML_SUCCESS &&
+            item->QueryAttribute("upper_velocity_limit", &vel_limits.second) == XML_SUCCESS)
+        {
+            has_limits = true;
+        }
+        }
+
+        if ((item = element->FirstChildElement("dynamics")) == nullptr)
+        {
+        log.Print(MessageType::ERROR, "Dynamics of actuator '%s' missing!", actuatorName.c_str());
+        return nullptr;
+        }
+
+        // Rotor model
+        std::shared_ptr<td::RotorDynamics> rotor_model;
+
+        const char* aux = nullptr;
+        std::string rotor_model_type = "";
+
+        if (item->QueryStringAttribute("type", &aux) == XML_SUCCESS)
+        {
+        rotor_model_type = std::string(aux);
+        }
+
+        if (rotor_model_type == "" || rotor_model_type == "zero_order")
+        {
+        rotor_model = std::make_shared<td::ZeroOrder>();
+        }
+        else
+        {
+        // Get params, an item that must be present in the rotor model except for the zero order model
+        auto params = item->FirstChildElement("params");
+        if (params == nullptr)
+        {
+            log.Print(MessageType::ERROR, "Rotor model parameters of actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+        }
+        // First order model
+        if (rotor_model_type == "first_order")
+        {
+            Scalar time_constant;
+            if (params->QueryAttribute("time_constant", &time_constant) != XML_SUCCESS)
+            {
+            log.Print(MessageType::ERROR, "Time constant of First Order rotor model in actuator '%s' missing!",
+                        actuatorName.c_str());
+            return nullptr;
+            }
+            rotor_model = std::make_shared<td::FirstOrder>(time_constant);
+        }
+        // Yoerger model
+        else if (rotor_model_type == "yoerger")
+        {
+            Scalar alpha, beta;
+            if (params->QueryAttribute("alpha", &alpha) != XML_SUCCESS ||
+                params->QueryAttribute("beta", &beta) != XML_SUCCESS)
+            {
+            log.Print(MessageType::ERROR, "Alpha or Beta of Yoerger rotor model in actuator '%s' missing!",
+                        actuatorName.c_str());
+            return nullptr;
+            }
+            rotor_model = std::make_shared<td::Yoerger>(alpha, beta);
+        }
+        // Bessa modoel
+        else if (rotor_model_type == "bessa")
+        {
+            Scalar jmsp, kv1, kv2, kt, rm;
+
+            if (params->QueryAttribute("jmsp", &jmsp) != XML_SUCCESS ||  //
+                params->QueryAttribute("kv1", &kv1) != XML_SUCCESS ||    //
+                params->QueryAttribute("kv2", &kv2) != XML_SUCCESS ||    //
+                params->QueryAttribute("kt", &kt) != XML_SUCCESS ||      //
+                params->QueryAttribute("rm", &rm) != XML_SUCCESS)
+            {
+            log.Print(MessageType::ERROR, "Bessa rotor model parameters in actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+            }
+            rotor_model = std::make_shared<td::Bessa>(jmsp, kv1, kv2, kt, rm);
+        }
+
+        //
+        else
+        {
+            log.Print(MessageType::ERROR, "Unknown rotor model type in actuator '%s'!", actuatorName.c_str());
+            return nullptr;
+        }
+        }
+
+        // Thrust Model
+        std::shared_ptr<td::ThrustModel> thrust_model;
+
+        std::string thrust_model_type = "";
+
+        if ((item = element->FirstChildElement("thrust_model")) == nullptr)
+        {
+        log.Print(MessageType::ERROR, "Thrust model of actuator '%s' missing!", actuatorName.c_str());
+        return nullptr;
+        }
+
+        if (item->QueryStringAttribute("type", &aux) == XML_SUCCESS)
+        {
+        thrust_model_type = std::string(aux);
+        }
+
+        // Basic
+        if (thrust_model_type == "basic")
+        {
+        Scalar cf;
+        // get params
+        auto params = item->FirstChildElement("params");
+        if (params == nullptr)
+        {
+            log.Print(MessageType::ERROR, "Thrust model parameters of actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+        }
+
+        if (params->QueryAttribute("rotor_constant", &cf) != XML_SUCCESS)
+        {
+            log.Print(MessageType::ERROR, "Basic thrust model rotor_constant of actuator '%s' missing!",
+                    actuatorName.c_str());
+            return nullptr;
+        }
+
+        thrust_model = std::make_shared<td::BasicThrustConversion>(cf);
+        }
+        // Dead-zone
+        else if (thrust_model_type == "deadzone")
+        {
+        Scalar rcl, rcr, dl, dr;
+
+        // get params
+        auto params = item->FirstChildElement("params");
+        if (params == nullptr)
+        {
+            log.Print(MessageType::ERROR, "Thrust model parameters of actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+        }
+
+        if (params->QueryAttribute("rotor_constant_left", &rcl) != XML_SUCCESS ||   //
+            params->QueryAttribute("rotor_constant_right", &rcr) != XML_SUCCESS ||  //
+            params->QueryAttribute("deadzone_left", &dl) != XML_SUCCESS ||          //
+            params->QueryAttribute("deadzone_right", &dr) != XML_SUCCESS)
+        {
+            log.Print(MessageType::ERROR, "Deadzone thrust model parameters in actuator '%s' missing!",
+                    actuatorName.c_str());
+            return nullptr;
+        }
+
+        thrust_model = std::make_shared<td::DeadBandConversion>(rcl, rcr, dl, dr);
+        }
+        // Linear Interpolation
+        else if (thrust_model_type == "linear_interp")
+        {
+        std::vector<Scalar> input, output;
+        // get params
+        const char* cinput;
+        const char* coutput;
+        if (item->QueryStringAttribute("input", &cinput) != XML_SUCCESS)
+        {
+            log.Print(MessageType::ERROR, "Linear interpolation input of actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+        }
+
+        if (item->QueryStringAttribute("output", &coutput) != XML_SUCCESS)
+        {
+            log.Print(MessageType::ERROR, "Linear interpolation output of actuator '%s' missing!", actuatorName.c_str());
+            return nullptr;
+        }
+
+        // Lambda function to convert a space-separated string to a vector of Scalars
+        // @TODO: Add as standard in the library?
+        auto stringToVector = [](const std::string& str) -> std::vector<Scalar> {
+            std::vector<Scalar> result;
+            std::stringstream ss(str);
+            Scalar temp;
+            while (ss >> temp)
+            {
+            result.push_back(temp);
+            }
+            return result;
+        };
+
+        input = stringToVector(std::string(cinput));
+        output = stringToVector(std::string(coutput));
+
+        thrust_model = std::make_shared<td::LinearInterpolation>(input, output);
+        }
+        //
+        else
+        {
+        log.Print(MessageType::ERROR, "Unknown thrust model type in actuator '%s'!", actuatorName.c_str());
+        return nullptr;
+        }
+
+        ConfigurableThruster* th;
+        if (!has_inverted)  // makes sure no assumpion is made about the inverted default value
+        th = new ConfigurableThruster(actuatorName, prop, rotor_model, thrust_model, rightHand);
+        else
+        th = new ConfigurableThruster(actuatorName, prop, rotor_model, thrust_model, rightHand, inverted);
+
+        if (has_limits)
+        {
+        th->setVelocityLimits(vel_limits.first, vel_limits.second);
+        }
+
+        return th;
+    }
+
     else if(typeStr == "simple_thruster")
     {
         const char* propFile = nullptr;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_definitions(-DDATA_DIR_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/Data/\")
 
+find_package(data_tamer_cpp QUIET)
+
 add_executable(ConsoleTest ConsoleTest/main.cpp ConsoleTest/ConsoleTestApp.cpp ConsoleTest/ConsoleTestManager.cpp)
 target_link_libraries(ConsoleTest Stonefish_test)
 
@@ -20,3 +22,23 @@ target_link_libraries(SlidingTest Stonefish_test)
 
 add_executable(UnderwaterTest UnderwaterTest/main.cpp UnderwaterTest/UnderwaterTestApp.cpp UnderwaterTest/UnderwaterTestManager.cpp)
 target_link_libraries(UnderwaterTest Stonefish_test)
+
+# if data tamer is found, compile the ConfigurableThrusterModel plots
+if(data_tamer_cpp_FOUND)
+    add_executable(PlotRotorModels ConfigurableThrusterModels/plot_rotor_models.cpp)
+    target_include_directories(PlotRotorModels
+    PUBLIC $<BUILD_INTERFACE:/opt/ros/humble/include>)
+    target_link_libraries(PlotRotorModels Stonefish_test /opt/ros/humble/lib/libdata_tamer.so)
+
+    add_executable(PlotThrustModels ConfigurableThrusterModels/plot_thruster_models.cpp)
+    target_include_directories(PlotThrustModels
+    PUBLIC $<BUILD_INTERFACE:/opt/ros/humble/include>)
+    target_link_libraries(PlotThrustModels Stonefish_test /opt/ros/humble/lib/libdata_tamer.so)
+
+    add_executable(ConfigurableThrusterTest ConfigurableThrusterTest/main.cpp ConfigurableThrusterTest/ConfigurableThrusterTestManager.cpp)
+    target_include_directories(ConfigurableThrusterTest
+    PUBLIC $<BUILD_INTERFACE:/opt/ros/humble/include>)
+    target_link_libraries(ConfigurableThrusterTest Stonefish_test /opt/ros/humble/lib/libdata_tamer.so)
+
+endif()
+

--- a/Tests/ConfigurableThrusterModels/plot_rotor_models.cpp
+++ b/Tests/ConfigurableThrusterModels/plot_rotor_models.cpp
@@ -6,10 +6,10 @@
 
 int main()
 {
-    sf::rm::ZeroOrder zeroOrder;
-    sf::rm::FirstOrder firstOrder(1.0);
-    sf::rm::Yoerger yoerger(0.037, 16.5);
-    sf::rm::Bessa bessa(1,1,1,1,1);
+    sf::td::ZeroOrder zeroOrder;
+    sf::td::FirstOrder firstOrder(1.0);
+    sf::td::Yoerger yoerger(0.037, 16.5);
+    sf::td::Bessa bessa(1,1,1,1,1);
 
     double time = 0.0;
     double sp = 0.0;

--- a/Tests/ConfigurableThrusterModels/plot_rotor_models.cpp
+++ b/Tests/ConfigurableThrusterModels/plot_rotor_models.cpp
@@ -1,0 +1,83 @@
+#include "actuators/ConfigurableThrusterModels.h"
+#include <iostream>
+#include "data_tamer/data_tamer.hpp"
+
+#include "data_tamer/sinks/mcap_sink.hpp"
+
+int main()
+{
+    sf::rm::ZeroOrder zeroOrder;
+    sf::rm::FirstOrder firstOrder(1.0);
+    sf::rm::Yoerger yoerger(0.037, 16.5);
+    sf::rm::Bessa bessa(1,1,1,1,1);
+
+    double time = 0.0;
+    double sp = 0.0;
+
+    double outputZeroOrder = zeroOrder.f(time, sp);
+    double outputFirstOrder = firstOrder.f(time, sp);
+    double outputYoerger = yoerger.f(time, sp);
+    double outputBessa = bessa.f(time, sp);
+
+    // Multiple channels can use this sink. Data will be saved in mylog.mcap
+  auto mcap_sink = std::make_shared<DataTamer::MCAPSink>("mylog.mcap");
+
+  // Create a channel and attach a sink. A channel can have multiple sinks
+  auto channel = DataTamer::LogChannel::create("dynamics");
+  channel->addDataSink(mcap_sink);
+
+  // You can register any arithmetic value. You are responsible for their lifetime!
+  auto id1 = channel->registerValue("outputZeroOrder", &outputZeroOrder);
+  auto id2 = channel->registerValue("outputFirstOrder", &outputFirstOrder);
+    auto id3 = channel->registerValue("outputYoerger", &outputYoerger);
+    auto id4 = channel->registerValue("outputBessa", &outputBessa);
+    auto id0 = channel->registerValue("setpoint", &sp);
+
+  // loop. First 10 seconds, setpoint is 0. Next 10 seconds setpoint is 20. Next 10 seconds, setpoint is again 0
+   double dt = 0.001;
+
+while(time < 90.0)
+{
+    if(time < 10.0)
+    {
+        sp = 0.0;
+    }
+    else if(time < 20.0)
+    {
+        sp = 50.0;
+    }
+    
+    else if (time < 40)
+    {
+        sp = 0.0;
+    }
+    else if (time < 60)
+    {
+        sp = 450.0;
+    }
+    else 
+    {
+        sp = 0.0;
+    }
+
+    outputZeroOrder = zeroOrder.f(time, sp);
+    outputFirstOrder = firstOrder.f(time, sp);
+    outputYoerger = yoerger.f(time, sp);
+    outputBessa = bessa.f(time, sp);
+
+    std::chrono::duration<double> duration(time);
+    std::chrono::nanoseconds ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+    channel->takeSnapshot(ns);
+
+    std::cout << "ns: " << ns.count() << std::endl;
+
+
+    time += dt;
+
+    // sleep for dt seconds
+    //std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(dt * 1000)));
+}
+
+
+    return 0;
+}

--- a/Tests/ConfigurableThrusterModels/plot_thruster_models.cpp
+++ b/Tests/ConfigurableThrusterModels/plot_thruster_models.cpp
@@ -1,0 +1,85 @@
+#include "actuators/ConfigurableThrusterModels.h"
+#include <iostream>
+#include "data_tamer/data_tamer.hpp"
+
+#include "data_tamer/sinks/mcap_sink.hpp"
+
+int main()
+{
+    sf::tm::BasicThrustConversion basic0001(0.001);
+    sf::tm::BasicThrustConversion basic0005(0.005);
+    sf::tm::BasicThrustConversion basic001(0.01);
+    sf::tm::BasicThrustConversion basic005(0.05);
+    sf::tm::BasicThrustConversion basic01(0.1);
+    sf::tm::BasicThrustConversion basic05(0.5);
+
+    sf::tm::DeadBandConversion db0001(0.001, 0.001 , - 30 * 30, 30 * 30);
+    sf::tm::DeadBandConversion db0005(0.005, 0.005 , - 30 * 30, 30 * 30);
+    sf::tm::DeadBandConversion db001(0.01, 0.01 , - 30 * 30, 30 * 30);
+    sf::tm::DeadBandConversion db005(0.05, 0.05 , - 30 * 30, 30 * 30);
+    sf::tm::DeadBandConversion db01(0.1, 0.1 , - 30 * 30, 30 * 30);
+    sf::tm::DeadBandConversion db05(0.5, 0.5 , - 30 * 30, 30 * 30);
+
+    double input;
+    double output0001, output0005, output001, output005, output01, output05;
+    double outputdb0001, outputdb0005, outputdb001, outputdb005, outputdb01, outputdb05;
+
+    // Multiple channels can use this sink. Data will be saved in mylog.mcap
+  auto mcap_sink = std::make_shared<DataTamer::MCAPSink>("mylog2.mcap");
+
+  // Create a channel and attach a sink. A channel can have multiple sinks
+  auto channel = DataTamer::LogChannel::create("conversions");
+  channel->addDataSink(mcap_sink);
+
+  // You can register any arithmetic value. You are responsible for their lifetime!
+  auto id1 = channel->registerValue("input", &input);
+    auto id2 = channel->registerValue("out0.001", &output0001);
+    auto id3 = channel->registerValue("out0.005", &output0005);
+    auto id4 = channel->registerValue("out0.01", &output001);
+    auto id5 = channel->registerValue("out0.05", &output005);
+    auto id6 = channel->registerValue("out0.1", &output01);
+    auto id7 = channel->registerValue("out0.5", &output05);
+
+    auto id8 = channel->registerValue("outdb0.001", &outputdb0001);
+    auto id9 = channel->registerValue("outdb0.005", &outputdb0005);
+    auto id10 = channel->registerValue("outdb0.01", &outputdb001);
+    auto id11 = channel->registerValue("outdb0.05", &outputdb005);
+    auto id12 = channel->registerValue("outdb0.1", &outputdb01);
+    auto id13 = channel->registerValue("outdb0.5", &outputdb05);
+
+
+  // loop. First 10 seconds, setpoint is 0. Next 10 seconds setpoint is 20. Next 10 seconds, setpoint is again 0
+   double dt = 0.001;
+
+   double start = -100;
+    double end = 100;
+
+
+    for (double i = start; i < end; i+=dt)
+    {
+        input = i;
+        output0001 = basic0001.f(input);
+        output0005 = basic0005.f(input);
+        output001 = basic001.f(input);
+        output005 = basic005.f(input);
+        output01 = basic01.f(input);
+        output05 = basic05.f(input);
+
+        outputdb0001 = db0001.f(input);
+        outputdb0005 = db0005.f(input);
+        outputdb001 = db001.f(input);
+        outputdb005 = db005.f(input);
+        outputdb01 = db01.f(input);
+        outputdb05 = db05.f(input);
+
+    channel->takeSnapshot();
+    std::cout << "input: " << input << std::endl;
+    }
+
+    return 0;
+
+
+    // sleep for dt seconds
+    //std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(dt * 1000)));
+}
+

--- a/Tests/ConfigurableThrusterModels/plot_thruster_models.cpp
+++ b/Tests/ConfigurableThrusterModels/plot_thruster_models.cpp
@@ -6,19 +6,19 @@
 
 int main()
 {
-    sf::tm::BasicThrustConversion basic0001(0.001);
-    sf::tm::BasicThrustConversion basic0005(0.005);
-    sf::tm::BasicThrustConversion basic001(0.01);
-    sf::tm::BasicThrustConversion basic005(0.05);
-    sf::tm::BasicThrustConversion basic01(0.1);
-    sf::tm::BasicThrustConversion basic05(0.5);
+    sf::td::BasicThrustConversion basic0001(0.001);
+    sf::td::BasicThrustConversion basic0005(0.005);
+    sf::td::BasicThrustConversion basic001(0.01);
+    sf::td::BasicThrustConversion basic005(0.05);
+    sf::td::BasicThrustConversion basic01(0.1);
+    sf::td::BasicThrustConversion basic05(0.5);
 
-    sf::tm::DeadBandConversion db0001(0.001, 0.001 , - 30 * 30, 30 * 30);
-    sf::tm::DeadBandConversion db0005(0.005, 0.005 , - 30 * 30, 30 * 30);
-    sf::tm::DeadBandConversion db001(0.01, 0.01 , - 30 * 30, 30 * 30);
-    sf::tm::DeadBandConversion db005(0.05, 0.05 , - 30 * 30, 30 * 30);
-    sf::tm::DeadBandConversion db01(0.1, 0.1 , - 30 * 30, 30 * 30);
-    sf::tm::DeadBandConversion db05(0.5, 0.5 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db0001(0.001, 0.001 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db0005(0.005, 0.005 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db001(0.01, 0.01 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db005(0.05, 0.05 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db01(0.1, 0.1 , - 30 * 30, 30 * 30);
+    sf::td::DeadBandConversion db05(0.5, 0.5 , - 30 * 30, 30 * 30);
 
     double input;
     double output0001, output0005, output001, output005, output01, output05;

--- a/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.cpp
+++ b/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.cpp
@@ -41,10 +41,10 @@ ConfigurableThrusterTestManager::ConfigurableThrusterTestManager(sf::Scalar step
   : SimulationManager(stepsPerSecond, sf::SolverType::SOLVER_SI, sf::CollisionFilteringType::COLLISION_EXCLUSIVE)
 {
   rotor_model_ =  //
-      std::make_shared<sf::rm::FirstOrder>(0.99999999);
+      std::make_shared<sf::td::FirstOrder>(0.99999999);
 
   thrust_model_ =  //
-      std::make_shared<sf::tm::BasicThrustConversion>(0.005);
+      std::make_shared<sf::td::BasicThrustConversion>(0.005);
 
   mcap_sink_ = std::make_shared<DataTamer::MCAPSink>("thruster_test.mcap");
 

--- a/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.cpp
+++ b/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.cpp
@@ -1,0 +1,163 @@
+/*
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  ConfigurableThrusterTestManager.cpp
+//  Stonefish
+//
+//  Created by Roger Pi on 06/10/2024.
+//  Copyright (c) 2024 Roger Pi. All rights reserved.
+//
+
+#include "ConfigurableThrusterTestManager.h"
+
+#include <entities/statics/Plane.h>
+#include <entities/statics/Obstacle.h>
+#include <entities/solids/Box.h>
+#include <actuators/Light.h>
+#include <sensors/scalar/Odometry.h>
+#include <utils/SystemUtil.hpp>
+#include <utils/UnitSystem.h>
+#include <entities/solids/Polyhedron.h>
+
+#include <core/FeatherstoneRobot.h>
+#include <entities/FeatherstoneEntity.h>
+
+ConfigurableThrusterTestManager::ConfigurableThrusterTestManager(sf::Scalar stepsPerSecond)
+  : SimulationManager(stepsPerSecond, sf::SolverType::SOLVER_SI, sf::CollisionFilteringType::COLLISION_EXCLUSIVE)
+{
+  rotor_model_ =  //
+      std::make_shared<sf::rm::FirstOrder>(0.99999999);
+
+  thrust_model_ =  //
+      std::make_shared<sf::tm::BasicThrustConversion>(0.005);
+
+  mcap_sink_ = std::make_shared<DataTamer::MCAPSink>("thruster_test.mcap");
+
+  // Create a channel and attach a sink. A channel can have multiple sinks
+  channel_ = DataTamer::LogChannel::create("output");
+  channel_->addDataSink(mcap_sink_);
+
+  channel_->registerValue("setpoint", &setpoint_);
+  channel_->registerValue("omega", &omega_);
+  channel_->registerValue("thrust", &thrust_);
+
+  double out = 0;
+  double in = 0;
+
+  auto channel2 = DataTamer::LogChannel::create("conv");
+  channel2->addDataSink(mcap_sink_);
+
+  channel2->registerValue("out", &out);
+  channel2->registerValue("in", &in);
+
+  for (in = -200; in < 200; in += 0.1)
+  {
+    out = thrust_model_->f(in);
+    channel2->takeSnapshot();
+    // sleep 0.01
+    std::this_thread::sleep_for(std::chrono::nanoseconds(10));
+  }
+}
+
+ConfigurableThrusterTestManager::~ConfigurableThrusterTestManager()
+{
+  // if (thruster_)
+  // {
+  //   delete thruster_;
+  // }
+}
+
+void ConfigurableThrusterTestManager::BuildScenario()
+{
+  ///////MATERIALS////////
+  CreateMaterial("Dummy", sf::UnitSystem::Density(sf::CGS, sf::MKS, 0.9), 0.3);
+  CreateMaterial("Fiberglass", sf::UnitSystem::Density(sf::CGS, sf::MKS, 1.5), 0.9);
+  CreateMaterial("Rock", sf::UnitSystem::Density(sf::CGS, sf::MKS, 3.0), 0.6);
+
+  SetMaterialsInteraction("Dummy", "Dummy", 0.5, 0.2);
+  SetMaterialsInteraction("Fiberglass", "Fiberglass", 0.5, 0.2);
+  SetMaterialsInteraction("Rock", "Rock", 0.9, 0.7);
+  SetMaterialsInteraction("Fiberglass", "Dummy", 0.5, 0.2);
+  SetMaterialsInteraction("Rock", "Dummy", 0.6, 0.4);
+  SetMaterialsInteraction("Rock", "Fiberglass", 0.6, 0.4);
+
+  ///////LOOKS///////////
+  CreateLook("yellow", sf::Color::RGB(1.f, 0.9f, 0.f), 0.3f, 0.f);
+  CreateLook("grey", sf::Color::RGB(0.3f, 0.3f, 0.3f), 0.4f, 0.5f);
+  CreateLook("black", sf::Color::RGB(0.1f, 0.1f, 0.1f), 0.4f, 0.5f);
+  CreateLook("seabed", sf::Color::RGB(0.7f, 0.7f, 0.5f), 0.9f, 0.f, 0.f, "", sf::GetDataPath() + "sand_normal.png");
+  CreateLook("propeller", sf::Color::RGB(1.f, 1.f, 1.f), 0.3f, 0.f, 0.f, sf::GetDataPath() + "propeller_tex.png");
+
+  ////////OBJECTS
+  EnableOcean(0.0);
+  getOcean()->setWaterType(0.2);
+  getAtmosphere()->SetupSunPosition(0.0, 60.0);
+
+  sf::Plane* floor = new sf::Plane("Floor", sf::Scalar(10000), "Rock", "seabed");
+  AddStaticEntity(floor, sf::Transform(sf::IQ(), sf::Vector3(0, 0, 5)));
+
+  sf::BodyPhysicsSettings phy;
+  phy.mode = sf::BodyPhysicsMode::SUBMERGED;
+  phy.collisions = true;
+  phy.buoyancy = false;
+
+  sf::Polyhedron* prop1 =                                      //
+      new sf::Polyhedron("Propeller", phy,                     //
+                         sf::GetDataPath() + "propeller.obj",  //
+                         sf::Scalar(1),                        //
+                         sf::I4(),                             //
+                         "Dummy", "propeller");
+
+  thruster_ =                                       //
+      new sf::ConfigurableThruster("ThrusterTest",  //
+                                   prop1,           //
+                                   rotor_model_,    //
+                                   thrust_model_,   //
+                                   true, false);
+
+  sf::FeatherstoneRobot* dummy_robot = new sf::FeatherstoneRobot("DummyRobot", true);
+
+  // Box
+  sf::Box* box = new sf::Box("Box", phy, sf::Vector3(0.01, 0.01, 0.01), sf::I4(), "Dummy", "grey");
+
+  dummy_robot->DefineLinks(box);
+  dummy_robot->BuildKinematicStructure();
+
+  dummy_robot->AddLinkActuator(thruster_, "Box", sf::Transform(sf::Quaternion(0, 0, 0), sf::Vector3(0.2, 0, 0)));
+
+  AddRobot(dummy_robot, sf::Transform(sf::IQ(), sf::Vector3(0, 0, 2)));
+
+  thruster_->setWatchdog(-1);
+  thruster_->setSetpoint(100);
+}
+
+void ConfigurableThrusterTestManager::SimulationStepCompleted(sf::Scalar timeStep)
+{
+  timestamp_ += timeStep;
+
+  if (timestamp_ > 10)
+  {
+    thruster_->setSetpoint(-100);
+  }
+
+  setpoint_ = thruster_->getSetpoint();
+  omega_ = thruster_->getOmega();
+  thrust_ = thruster_->getThrust();
+
+  channel_->takeSnapshot();
+}

--- a/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.h
+++ b/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.h
@@ -54,8 +54,8 @@ protected:
 
   sf::Scalar timestamp_;
 
-  std::shared_ptr<sf::rm::RotorDynamics> rotor_model_;
-  std::shared_ptr<sf::tm::ThrustModel> thrust_model_;
+  std::shared_ptr<sf::td::RotorDynamics> rotor_model_;
+  std::shared_ptr<sf::td::ThrustModel> thrust_model_;
 
   sf::ConfigurableThruster* thruster_;
 };

--- a/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.h
+++ b/Tests/ConfigurableThrusterTest/ConfigurableThrusterTestManager.h
@@ -1,0 +1,61 @@
+/*
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  ConfigurableThrusterTestManager.h
+//  Stonefish
+//
+//  Created by Roger Pi on 06/10/2024.
+//  Copyright (c) 2024 Roger Pi. All rights reserved.
+//
+
+#pragma once
+
+#include <core/SimulationManager.h>
+#include <memory>
+
+#include "data_tamer/data_tamer.hpp"
+#include "data_tamer/sinks/mcap_sink.hpp"
+#include <actuators/ConfigurableThruster.h>
+
+
+class ConfigurableThrusterTestManager : public sf::SimulationManager
+{
+public:
+  ConfigurableThrusterTestManager(sf::Scalar stepsPerSecond);
+
+  virtual ~ConfigurableThrusterTestManager();
+
+  void BuildScenario();
+
+  void SimulationStepCompleted(sf::Scalar timeStep) override;
+
+protected:
+  std::shared_ptr<DataTamer::MCAPSink> mcap_sink_;
+  std::shared_ptr<DataTamer::LogChannel> channel_;
+
+  sf::Scalar setpoint_;
+  sf::Scalar omega_;
+  sf::Scalar thrust_;
+
+  sf::Scalar timestamp_;
+
+  std::shared_ptr<sf::rm::RotorDynamics> rotor_model_;
+  std::shared_ptr<sf::tm::ThrustModel> thrust_model_;
+
+  sf::ConfigurableThruster* thruster_;
+};

--- a/Tests/ConfigurableThrusterTest/main.cpp
+++ b/Tests/ConfigurableThrusterTest/main.cpp
@@ -1,0 +1,56 @@
+/*    
+    This file is a part of Stonefish.
+
+    Stonefish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Stonefish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+//
+//  main.cpp
+//  Stonefish
+//
+//  Created by Roger Pi on 06/10/2024.
+//  Copyright (c) 2024 Roger Pi. All rights reserved.
+//
+
+
+#include <core/GraphicalSimulationApp.h>
+#include "ConfigurableThrusterTestManager.h"
+
+int main(int argc, const char * argv[])
+{
+    sf::RenderSettings s;
+    s.windowW = 1200;
+    s.windowH = 900;
+    s.aa = sf::RenderQuality::HIGH;
+    s.shadows = sf::RenderQuality::HIGH;
+    s.ao = sf::RenderQuality::HIGH;
+    s.atmosphere = sf::RenderQuality::HIGH;
+    s.ocean = sf::RenderQuality::HIGH;
+    
+    sf::HelperSettings h;
+    h.showFluidDynamics = false;
+    h.showCoordSys = false;
+    h.showBulletDebugInfo = false;
+    h.showSensors = false;
+    h.showActuators = false;
+    h.showForces = false;
+    h.showJoints = false;
+    
+    ConfigurableThrusterTestManager simulationManager(500.0);
+    sf::GraphicalSimulationApp app("ThrusterTest", std::string(DATA_DIR_PATH), s, h, &simulationManager);
+    app.Run();
+    
+    return 0;
+}
+


### PR DESCRIPTION
This pull requests adds a configurable thruster.

It allows to configure the following rotor dynamics:

- Zero Order
- First Order
- Yoerger [Yoerger](https://ieeexplore.ieee.org/document/107145)
- Bessa [Bessa](https://www.abcm.org.br/symposium-series/SSM_Vol2/Section_IX_Submarine_Robotics/SSM2_IX_01.pdf)

And the following angular velocity to thrust conversions:

- Basic
- Deadband
- Linear Interpolation

