### PR TITLE
replaced old enum definition in docs

### DIFF
--- a/docs/actuators.rst
+++ b/docs/actuators.rst
@@ -140,7 +140,7 @@ A propeller is an actuator working in atmosphere, representing an airplane prope
 .. code-block:: cpp
 
     #include <Stonefish/actuators/Propeller.h>
-    sf::Polyhedron* propMesh = new sf::Polyhedron("PropMesh", sf::BodyPhysicsType::AERODYNAMIC, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
+    sf::Polyhedron* propMesh = new sf::Polyhedron("PropMesh", sf::BodyPhysicsMode::AERODYNAMIC, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
     sf::Propeller* propeller = new sf::Propeller("Prop", propMesh, 0.5, 0.45, 0.02, 1000, true, false);
     robot->AddLinkActuator(propeller, "Link1", sf::I4()); 
 
@@ -165,7 +165,7 @@ A simple thruster is an extension of the *push* actuator that functions only und
 .. code-block:: cpp
 
     #include <Stonefish/actuators/SimpleThruster.h>
-    sf::Polyhedron* propMesh = new sf::Polyhedron("PropMesh", sf::BodyPhysicsType::SUBMERGED, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
+    sf::Polyhedron* propMesh = new sf::Polyhedron("PropMesh", sf::BodyPhysicsMode::SUBMERGED, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
     sf::SimpleThruster* thruster = new sf::SimpleThruster("SimpleThruster", propMesh, true, false);
     robot->AddLinkActuator(thruster, "Link1", sf::I4()); 
 
@@ -333,7 +333,7 @@ An example of a full thruster definition utilising the XML syntax and the C++ co
 .. code-block:: cpp
 
     #include <Stonefish/actuators/Thruster.h>
-    sf::Polyhedron* prop = new sf::Polyhedron("PropMesh", sf::BodyPhysicsType::SUBMERGED, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
+    sf::Polyhedron* prop = new sf::Polyhedron("PropMesh", sf::BodyPhysicsMode::SUBMERGED, sf::GetDataPath() + "propeller.obj", 1.0, sf::I4(), "Steel", "Red");
     std::shared_ptr<sf::MechanicalPI> rotorDynamics;
     rotorDynamics = std::make_shared<sf::MechanicalPI>(1.0, 10.0, 5.0, 5.0);
     std::shared_ptr<sf::FDThrust> thrustModel;

--- a/docs/bodies.rst
+++ b/docs/bodies.rst
@@ -24,7 +24,7 @@ The following diagram presents the coordinate frames defined for a dynamic body.
 Physics mode
 ^^^^^^^^^^^^
 
-Dynamic bodies are affected by different forces, depending on the type of environment, the position of the body with respect to the ocean surface (if it is enabled) and the selected body physics mode. The last one was introduced as an optimization to help determine which forces have to be computed for a specific body and thus how the body should be prepared for the simulation. The physics mode of each dynamic body ``sf::BodyPhysicsType`` has to be selected from one of the following options:
+Dynamic bodies are affected by different forces, depending on the type of environment, the position of the body with respect to the ocean surface (if it is enabled) and the selected body physics mode. The last one was introduced as an optimization to help determine which forces have to be computed for a specific body and thus how the body should be prepared for the simulation. The physics mode of each dynamic body ``sf::BodyPhysicsMode`` has to be selected from one of the following options:
 
 -  ``SURFACE`` - no aerodynamic or hydrodynamic forces computed
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -92,7 +92,7 @@ Following the steps above should result in 3 new files: *main.cpp*, *MySimulatio
         AddStaticEntity(plane, sf::I4());
 
         //Create object
-        sf::Sphere* sph = new sf::Sphere("Sphere", 0.1, sf::I4(), "Aluminium", sf::BodyPhysicsType::SURFACE, "red");
+        sf::Sphere* sph = new sf::Sphere("Sphere", 0.1, sf::I4(), "Aluminium", sf::BodyPhysicsMode::SURFACE, "red");
         AddSolidEntity(sph, sf::Transform(sf::IQ(), sf::Vector3(0.0,0.0,-1.0)));
     }
 

--- a/docs/robots.rst
+++ b/docs/robots.rst
@@ -88,9 +88,9 @@ Below, an example of defining a complete robot is presented, first using the XML
 .. code-block:: cpp
 
     //1. Defining links
-    sf::Sphere* base = new sf::Sphere("Base", 0.2, sf::I4(), "Steel", sf::BodyPhysicsType::SURFACE, "Green");
-    sf::Box* link1 = new sf::Box("Link1", sf::Vector3(0.1, 0.02, 0.5), sf::Transform(sf::Quaternion(M_PI_2, 0.0, 0.0), sf::Vector3(0.0, 0.0, -0.2)), "Steel", sf::BodyPhysicsType::SURFACE, "Green");
-    sf::Box* link2 = new sf::Box("Link2", sf::Vector3(0.1, 0.02, 0.5), sf::Transform(sf::Quaternion(M_PI_2, 0.0, 0.0), sf::Vector3(0.0, 0.0, -0.2)), "Steel", sf::BodyPhysicsType::SURFACE, "Green");
+    sf::Sphere* base = new sf::Sphere("Base", 0.2, sf::I4(), "Steel", sf::BodyPhysicsMode::SURFACE, "Green");
+    sf::Box* link1 = new sf::Box("Link1", sf::Vector3(0.1, 0.02, 0.5), sf::Transform(sf::Quaternion(M_PI_2, 0.0, 0.0), sf::Vector3(0.0, 0.0, -0.2)), "Steel", sf::BodyPhysicsMode::SURFACE, "Green");
+    sf::Box* link2 = new sf::Box("Link2", sf::Vector3(0.1, 0.02, 0.5), sf::Transform(sf::Quaternion(M_PI_2, 0.0, 0.0), sf::Vector3(0.0, 0.0, -0.2)), "Steel", sf::BodyPhysicsMode::SURFACE, "Green");
 
     std::vector<sf::SolidEntity*> links;
     links.push_back(link1);


### PR DESCRIPTION
Documentation has old definition for enum declaration that was changed in commit 1886d6452be68ea3e2b1328b50e6ae6c862f1df2.
Old: ``sf::BodyPhysicsType``
Current: ``sf::BodyPhysicsMode``