### PR TITLE
Fixed shaders failing to compile with the Mesa library.

### DIFF
--- a/Library/shaders/colorMapping.glsl
+++ b/Library/shaders/colorMapping.glsl
@@ -5,50 +5,50 @@ const float perulaB[256] = float[](0.5292, 0.5411, 0.553, 0.565, 0.5771, 0.5892,
 
 vec3 applyColorMapping(float value, int cmap)
 {
-    vec3 output;
+    vec3 color;
     switch(cmap)
     {
         case 0: //Hot
-            output.r = clamp(1.0/0.4*value, 0.0, 1.0);
-            output.g = clamp(1.0/0.4*(value-0.4), 0.0, 1.0);
-            output.b = clamp(1.0/0.2*(value-0.8), 0.0, 1.0);
+            color.r = clamp(1.0/0.4*value, 0.0, 1.0);
+            color.g = clamp(1.0/0.4*(value-0.4), 0.0, 1.0);
+            color.b = clamp(1.0/0.2*(value-0.8), 0.0, 1.0);
             break;
             
         case 1: //Jet
-            output.r = clamp((value-0.375)*4.0, 0.0, 1.0) - clamp((value-0.875)*4.0, 0.0, 0.5);
-            output.g = clamp((value-0.125)*4.0, 0.0, 1.0) - clamp((value-0.625)*4.0, 0.0, 1.0);
-            output.b = 0.5 + clamp(value*4.0, 0.0, 0.5) - clamp((value-0.375)*4.0, 0.0, 1.0);
+            color.r = clamp((value-0.375)*4.0, 0.0, 1.0) - clamp((value-0.875)*4.0, 0.0, 0.5);
+            color.g = clamp((value-0.125)*4.0, 0.0, 1.0) - clamp((value-0.625)*4.0, 0.0, 1.0);
+            color.b = 0.5 + clamp(value*4.0, 0.0, 0.5) - clamp((value-0.375)*4.0, 0.0, 1.0);
             break;
             
         case 2: //Perula
             int i = int(clamp(value*255.0, 0.0, 255.0));
-            output.r = perulaR[i];
-            output.g = perulaG[i];
-            output.b = perulaB[i];
+            color.r = perulaR[i];
+            color.g = perulaG[i];
+            color.b = perulaB[i];
             break;
             
         case 3: //Green-blue
-            output.r = clamp(cos((value-1.0)*2.0),0.0,1.0)*0.9;
-            output.g = clamp(cos((value-1.0)*1.57),0.0,1.0);
-            output.b = clamp(cos((value-0.3)*8.0)*0.5+0.5,0.0,1.0)*0.5;
+            color.r = clamp(cos((value-1.0)*2.0),0.0,1.0)*0.9;
+            color.g = clamp(cos((value-1.0)*1.57),0.0,1.0);
+            color.b = clamp(cos((value-0.3)*8.0)*0.5+0.5,0.0,1.0)*0.5;
             break;
 
         default:   
         case 4: //Orange-copper
-            output.r = clamp(value*1.3+0.3, 0.0, 1.0);
-            output.g = clamp(value*1.5-0.2, 0.0, 1.0);
-            output.b = clamp(value*2.0-1.0, 0.0, 1.0);
+            color.r = clamp(value*1.3+0.3, 0.0, 1.0);
+            color.g = clamp(value*1.5-0.2, 0.0, 1.0);
+            color.b = clamp(value*2.0-1.0, 0.0, 1.0);
             break;
 
         case 5: //Blue
-            output.r = clamp(value*2.0-1.0, 0.0, 1.0);
-            output.g = clamp(value*1.5-0.2, 0.0, 1.0);
-            output.b = clamp(value*1.3+0.3, 0.0, 1.0);
+            color.r = clamp(value*2.0-1.0, 0.0, 1.0);
+            color.g = clamp(value*1.5-0.2, 0.0, 1.0);
+            color.b = clamp(value*1.3+0.3, 0.0, 1.0);
             break;
 
         case 6: //Grey
-            output = vec3(clamp(value, 0.0, 1.0));
+            color = vec3(clamp(value, 0.0, 1.0));
             break;
     }
-    return output;
+    return color;
 }

--- a/Library/shaders/hbaoBlur.frag
+++ b/Library/shaders/hbaoBlur.frag
@@ -35,7 +35,7 @@ layout(location=0,index=0) out vec4 fragColor;
 
 float BlurFunction(vec2 uv, float r, float center_c, float center_d, inout float w_total)
 {
-	vec2  aoz = texture2D(texSource, uv).xy;
+	vec2  aoz = texture(texSource, uv).xy;
 	float c = aoz.x;
 	float d = aoz.y;
   
@@ -51,7 +51,7 @@ float BlurFunction(vec2 uv, float r, float center_c, float center_d, inout float
 
 void main()
 {
-	vec2  aoz = texture2D(texSource, texcoord).xy;
+	vec2  aoz = texture(texSource, texcoord).xy;
 	float center_c = aoz.x;
 	float center_d = aoz.y;
   

--- a/Library/shaders/hbaoBlur2.frag
+++ b/Library/shaders/hbaoBlur2.frag
@@ -35,7 +35,7 @@ layout(location=0,index=0) out vec4 fragColor;
 
 float BlurFunction(vec2 uv, float r, float center_c, float center_d, inout float w_total)
 {
-	vec2  aoz = texture2D(texSource, uv).xy;
+	vec2  aoz = texture(texSource, uv).xy;
 	float c = aoz.x;
 	float d = aoz.y;
   
@@ -51,7 +51,7 @@ float BlurFunction(vec2 uv, float r, float center_c, float center_d, inout float
 
 void main()
 {
-	vec2  aoz = texture2D(texSource, texcoord).xy;
+	vec2  aoz = texture(texSource, texcoord).xy;
 	float center_c = aoz.x;
 	float center_d = aoz.y;
   


### PR DESCRIPTION
This PR fixes fixes issues #65 and #53.

When running one of the test scripts provided in this program, such as UnderwaterTest, the visualizations for the forward-looking scanner, side-scan sonar, and mechanical-scanning imaging sonar all appear as white.

This PR replaces the use of the deprecated `texture2D` with `texture` and replaces the variable name `output` (which is reserved) with `color`.

Before:
<img width="1228" height="966" alt="image" src="https://github.com/user-attachments/assets/5f5df988-4aa7-4bb0-969b-db900ded0174" />

After:
<img width="1228" height="966" alt="image" src="https://github.com/user-attachments/assets/de055dfb-4a8d-4fcb-86bf-18c0dca26371" />
