### PR TITLE
fix(docs): Documentation Updates in "Building a simple graphical simulator section"

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -165,5 +165,6 @@ Example of creating a button widget (*note:* ``MySimulationApp`` is a subclass o
         button.item = 10;  //e.g. id of an option on a list (item 1 to 8 used by standard GUI) 
 
         if(getGUI()->DoButton(button, 200, 10, 200, 50, "Press me"))
-            code_to_execute;
+            //code_to_execute (e.g. Console info log) 
+            cInfo("Button Pressed");          
     }


### PR DESCRIPTION
Changes In [**Stonefish Documentation > Building a simulator > Building a simple graphical simulator**](https://stonefish.readthedocs.io/en/latest/building.html)
(in the description of `MySimulationManager.cpp`) 

Replacing `sf::BodyPhysicsType::SURFACE` with the up to date definition `sf::BodyPhysicsMode::SURFACE`

As noticed by @sladelley on [Issue#61](https://github.com/patrykcieslak/stonefish/issues/61) 