### PR TITLE
Fix Segfault When UnderwaterTest is Stopped

### DIFF
--- a/Library/include/entities/MovingEntity.h
+++ b/Library/include/entities/MovingEntity.h
@@ -28,6 +28,7 @@
 #include "core/MaterialManager.h"
 #include "entities/Entity.h"
 #include "graphics/OpenGLDataStructs.h"
+#include <memory>
 
 namespace sf
 {
@@ -129,7 +130,7 @@ namespace sf
         int getGraphicalObject() const;
 
         //! A method returning the associated particles system.
-        OpenGLOceanParticles* getOceanParticles();
+        std::shared_ptr<OpenGLOceanParticles> getOceanParticles();
 
         //! A method returning the rigid body associated with the entity.
         btRigidBody* getRigidBody();
@@ -144,13 +145,13 @@ namespace sf
         Vector3 filteredAngularVel;
         Vector3 linearAcc;
         Vector3 angularAcc;
-        
+
         //Display
         int lookId;
         int graObjectId;
         DisplayMode dm;
-        OpenGLOceanParticles* particles;
-        
+        std::shared_ptr<OpenGLOceanParticles> particles;
+
     private:
     };
 }

--- a/Library/include/graphics/OpenGLOcean.h
+++ b/Library/include/graphics/OpenGLOcean.h
@@ -29,6 +29,7 @@
 #include "graphics/OpenGLContent.h"
 #include <SDL2/SDL_mutex.h>
 #include <map>
+#include <memory>
 
 namespace sf
 {
@@ -169,14 +170,14 @@ namespace sf
          \param view a pointer to the view.
          \return a pointer to the allocated particle system
          */
-        OpenGLOceanParticles* AllocateParticles(OpenGLView* view);
+        std::shared_ptr<OpenGLOceanParticles> AllocateParticles(OpenGLView* view);
 
         //! A method to assign particle system to a view.
         /*!
          \param view a pointer to the view.
          \param particles a pointer to the particle system
          */
-        void AssignParticles(OpenGLView* view, OpenGLOceanParticles* particles);
+        void AssignParticles(OpenGLView* view, std::shared_ptr<OpenGLOceanParticles> particles);
 
         //! A method to set the type of ocean water.
         /*!
@@ -229,7 +230,7 @@ namespace sf
         virtual void InitializeSimulation();
         float sqr(float x);
         
-        std::map<OpenGLView*, OpenGLOceanParticles*> oceanParticles;
+        std::map<OpenGLView*, std::shared_ptr<OpenGLOceanParticles>> oceanParticles;
         glm::vec3 absorption[64];
         glm::vec3 scattering[64];
         OceanCurrentsUBO oceanCurrentsUBOData;

--- a/Library/src/entities/MovingEntity.cpp
+++ b/Library/src/entities/MovingEntity.cpp
@@ -30,6 +30,7 @@
 #include "graphics/OpenGLPipeline.h"
 #include "graphics/OpenGLContent.h"
 #include "graphics/OpenGLOceanParticles.h"
+#include <memory>
 
 namespace sf
 {
@@ -49,8 +50,6 @@ MovingEntity::MovingEntity(std::string uniqueName, std::string material, std::st
 
 MovingEntity::~MovingEntity()
 {
-    if(particles != nullptr)
-        delete particles;
 }
 
 Material MovingEntity::getMaterial() const
@@ -88,13 +87,13 @@ int MovingEntity::getGraphicalObject() const
     return graObjectId;
 }
 
-OpenGLOceanParticles* MovingEntity::getOceanParticles()
+std::shared_ptr<OpenGLOceanParticles> MovingEntity::getOceanParticles()
 {
-    if(particles == nullptr 
-        && SimulationApp::getApp()->hasGraphics() 
+    if(particles == nullptr
+        && SimulationApp::getApp()->hasGraphics()
         && SimulationApp::getApp()->getSimulationManager()->isOceanEnabled())
     {
-        particles = new OpenGLOceanParticles(STD_OCEAN_PARTICLES_COUNT, STD_OCEAN_PARTICLES_RADIUS);
+        particles = std::make_shared<OpenGLOceanParticles>(STD_OCEAN_PARTICLES_COUNT, STD_OCEAN_PARTICLES_RADIUS);
     }
 
     return particles;

--- a/Tests/CameraTest/CameraTestManager.cpp
+++ b/Tests/CameraTest/CameraTestManager.cpp
@@ -41,6 +41,10 @@
 #include <sensors/vision/SegmentationCamera.h>
 #include <iostream>
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 CameraTestManager::CameraTestManager(sf::Scalar stepsPerSecond)
    : SimulationManager(stepsPerSecond, sf::Solver::SI, sf::CollisionFilter::EXCLUSIVE)
 {


### PR DESCRIPTION
When the UnderwaterTest is stopped, a segfault occurs:
```
[INFO] Welcome to Stonefish 1.6.
[INFO] Window created. OpenGL 4.6 contexts created.
[INFO] Checking GPU capabilities...
[INFO] Number of texture units available: 192
[INFO] Maximum texture size: 16384
[INFO] Maximum number of texture layers: 8192
[INFO] Maximum number of fragment shader uniforms: 16384
[INFO] Setting up OpenGL...
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Library/shaders/logo_64.png
[INFO] Initializing rendering pipeline:
[INFO] Loading GUI...
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Library/shaders/logo_gray_64.png
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Library/shaders/gui.png
[INFO] Initialising OpenGL rendering pipeline...
[INFO] Loading shaders...
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Library/shaders/flake.png
[INFO] Initializing simulation:
[INFO] Building scenario...
[INFO] Loaded precomputed atmosphere model (20 wavelengths, 5 scattering orders)
[INFO] Material Dummy (0) created.
[INFO] Material Fiberglass (1) created.
[INFO] Material Rock (2) created.
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/sand_normal.png
[WARN] Texture has 4 channels while expected 3 channels!
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/propeller_tex.png
[WARN] Texture has 4 channels while expected 3 channels!
[INFO] Loaded texture from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/link4_tex.png
[INFO] Generating ocean waves...
[ERROR] Failed to link program!
[ERROR] Failed to link program!
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/hull_hydro.obj
[INFO] Loaded mesh with 2880 faces in 1 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/hull_hydro.obj
[INFO] Loaded mesh with 2880 faces in 1 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/hull_hydro.obj
[INFO] Loaded mesh with 2880 faces in 1 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/vbar_hydro.obj
[INFO] Loaded mesh with 126 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/vbar_hydro.obj
[INFO] Loaded mesh with 126 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/duct_hydro.obj
[INFO] Loaded mesh with 372 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/duct_hydro.obj
[INFO] Loaded mesh with 372 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/duct_hydro.obj
[INFO] Loaded mesh with 372 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/duct_hydro.obj
[INFO] Loaded mesh with 372 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/duct_hydro.obj
[INFO] Loaded mesh with 372 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/base_link_uji_hydro.obj
[INFO] Loaded mesh with 124 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/link1_hydro.obj
[INFO] Loaded mesh with 254 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/link2_hydro.obj
[INFO] Loaded mesh with 358 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/link3_hydro.obj
[INFO] Loaded mesh with 566 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/link4ft_hydro.obj
[INFO] Loaded mesh with 282 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/eeprobe_hydro.obj
[INFO] Loaded mesh with 248 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/fingerA_hydro.obj
[INFO] Loaded mesh with 76 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/fingerA_hydro.obj
[INFO] Loaded mesh with 76 faces in 0 ms.
[INFO] Loading geometry from: /home/kethan/Coding/AVBotz/high/stonefish/Tests/Data/propeller.obj
[INFO] Loaded mesh with 900 faces in 2 ms.
[INFO] Built multibody link Vehicle (mass[kg]: 138.507; inertia[kgm2]: 94.111, 131.752, 139.138; volume[cm3]: 147060.8)
[INFO] Building kinematic tree of robot 'GIRONA500', consisting of 9 links and 8 joints.
[INFO] Joint 1: Vehicle<-->ArmBaseLink
[INFO] Joint 2: ArmBaseLink<-->ArmLink1
[INFO] Joint 3: ArmLink1<-->ArmLink2
[INFO] Joint 4: ArmLink2<-->ArmLink3
[INFO] Joint 5: ArmLink3<-->ArmLink4
[INFO] Joint 6: ArmLink4<-->EE
[INFO] Joint 7: EE<-->Finger2
[INFO] Joint 8: EE<-->Finger1
[INFO] Built multibody link ArmBaseLink (mass[kg]: 3.554; inertia[kgm2]: 0.007, 0.038, 0.038; volume[cm3]: 3948.7)
[INFO] Built multibody link ArmLink1 (mass[kg]: 0.760; inertia[kgm2]: 0.001, 0.002, 0.002; volume[cm3]: 844.7)
[INFO] Built multibody link ArmLink2 (mass[kg]: 5.160; inertia[kgm2]: 0.021, 0.035, 0.043; volume[cm3]: 5733.7)
[INFO] Built multibody link ArmLink3 (mass[kg]: 1.364; inertia[kgm2]: 0.002, 0.005, 0.006; volume[cm3]: 1515.9)
[INFO] Built multibody link ArmLink4 (mass[kg]: 0.277; inertia[kgm2]: 0.000, 0.000, 0.000; volume[cm3]: 307.5)
[INFO] Built multibody link EE (mass[kg]: 0.419; inertia[kgm2]: 0.000, 0.000, 0.000; volume[cm3]: 465.9)
[INFO] Built multibody link Finger2 (mass[kg]: 0.100; inertia[kgm2]: 0.000, 0.000, 0.000; volume[cm3]: 111.0)
[INFO] Built multibody link Finger1 (mass[kg]: 0.100; inertia[kgm2]: 0.000, 0.000, 0.000; volume[cm3]: 111.0)
[INFO] Finalizing OpenGL rendering pipeline...
[INFO] Synchronizing motion states...
[INFO] Simulation initialized -> using Bullet Physics 3.26.
[INFO] Ready for running...
[INFO] IC problem solved with 1 iterations in 0.000236 s.
[ThrusterSurgePort] RPM: 0, Thrust: 0
[1]    346660 segmentation fault (core dumped)  ./Tests/UnderwaterTest
```

This doesn't seem to affect functionality at all and only manifests itself when the simulator is stopped (though it does seem the cause the simulator window to hang for ~0.3s after the X button is pressed).

It appears to be caused by a pointer to OpenGLOceanParticles being deleted twice, in the destructors of MovingEntity and OpenGLOcean. I attempted to solve this by using shared_ptrs instead of raw pointers.