### PR TITLE
Fix inverse-square attenuation for shadowed lights

### DIFF
--- a/Library/shaders/lighting.frag
+++ b/Library/shaders/lighting.frag
@@ -651,7 +651,7 @@ vec4 PointLightContribution(int id, vec3 P, vec3 N, vec3 toEye, vec3 albedo)
 	vec3 toLight = pointLights[id].position - P;                //Vector from point to light
 	float dist = max(pointLights[id].radius, length(toLight));  //Not possible to be closer than the light surface
     toLight /= dist;                                            //Normalize point-light vector
-	float attenuation = 1.0/dist*dist;                          //Inverse square law
+	float attenuation = 1.0/(dist*dist);                        //Inverse square law
 	return vec4(ShadingModel(N, toEye, toLight, pointLights[id].color * attenuation, albedo), dist);
 }
 
@@ -664,7 +664,7 @@ vec4 SpotLightContribution(int id, vec3 P, vec3 N, vec3 toEye, vec3 albedo)
     float NdotL = dot(N, toLight);
 	if(spotEffect > spotLights[id].cone && NdotL > 0.0)                     //In spotlight?
 	{
-		float attenuation = 1.0/distance*distance;                          //Inverse square law
+		float attenuation = 1.0/(distance*distance);                        //Inverse square law
         float edge = smoothstep(1, 1.05, spotEffect/spotLights[id].cone);   //Smooth spot edge
 		return vec4(ShadingModel(N, toEye, toLight, spotLights[id].color * SpotShadow(id, P) * edge * attenuation, albedo), distance);
 	}


### PR DESCRIPTION
# Fixed inverse-square attenuation for shadowed lights

This PR fixes the distance attenuation of shadowed point and spot lights.

Multiplication and division have equal precedence in GLSL and are evaluated from left to right. Therefore:

```glsl
1.0 / distance * distance
```

is evaluated as:

```glsl
(1.0 / distance) * distance
```

which is approximately `1.0` for positive distances. This contradicts the adjacent `Inverse square law` comments. The non-shadowed lighting path and underwater light scattering already use `1.0 / (distance * distance)`.

The patch adds the missing parentheses to both shadowed-light functions.

Tested by:

- building the current `master` (`b21eb8e`) in Release mode;
- running a GPU A/B scene with identical shadow-casting spotlights at 1, 2, 4 and 8 m;
- verifying that the old path had nearly constant brightness from 2 to 8 m, while the corrected path produced monotonic distance falloff.
