### PR TITLE
fix: use GL_LINEAR for texture magnification filter

### DIFF
--- a/Library/src/graphics/OpenGLContent.cpp
+++ b/Library/src/graphics/OpenGLContent.cpp
@@ -1476,7 +1476,7 @@ GLuint OpenGLContent::LoadTexture(const std::string& filename, bool srgb, bool a
     else
         glTexImage2D(GL_TEXTURE_2D, 0, alpha ? GL_RGBA8 : GL_RGB8, width, height, 0, alpha? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, dataBuffer);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     if(anisotropy > 0.f)
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);


### PR DESCRIPTION
GL_TEXTURE_MAG_FILTER only accepts GL_NEAREST/GL_LINEAR. The mipmap modes are min-filter only. 

GL_LINEAR_MIPMAP_LINEAR here raises GL_INVALID_ENUM and is silently ignored (falls back to the GL_LINEAR default). This PR just set it to GL_LINEAR explicitly.